### PR TITLE
fix(ldap): verify user credentials before unbind, harden login flow

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,9 @@ LDAP:
     uri:    'ldap://127.0.0.1:389'
     scope:  'subtree'
     base_dn: 'OU=People,DC=example,DC=org'
+    # additional filter, automatically combined with the login attribute match:
+    # (&(<login_attribute>=<username>)<filter>)
+    # no placeholder substitution takes place, leave empty to match on the login attribute only
     filter: '(&(objectClass=inetOrgPerson)(memberOf=CN=keepass,OU=groups,DC=example,DC=org))'
 
     # (unique) ldap attribute for user login

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -18,6 +18,20 @@ impl Ldap {
             config: config.ldap.clone()
         }
     }
+
+    // resulting filter: (&(<login_attribute>=<username>)<configured filter>),
+    // or just (<login_attribute>=<username>) if no filter is configured
+    fn search_filter(&self, username: &str) -> String {
+        let user_match = format!(
+            "({}={})",
+            self.config.login_attribute,
+            ldap_escape(username),
+        );
+        match self.config.filter.trim() {
+            "" | "()" => user_match,
+            filter => format!("(&{}{})", user_match, filter),
+        }
+    }
 }
 
 #[async_trait]
@@ -27,13 +41,19 @@ impl AuthBackend for Ldap {
     }
 
     async fn login(&self, username: &str, password: &str) -> Result<UserInfo> {
+        // an empty password would result in an anonymous bind, which most ldap
+        // servers report as success, bypassing the password check entirely
+        if password.is_empty() {
+            bail!("empty password");
+        }
+
         let (conn, mut ldap) = LdapConnAsync::new(self.config.uri.as_str()).await?;
 
         drive!(conn);
         ldap.simple_bind(
             self.config.bind.as_str(),
             self.config.password.as_str(),
-        ).await?;
+        ).await?.success()?;
 
         let mut attrs = vec![CN_ATTR];
         if let Some(k) = &self.config.database_attribute {
@@ -44,25 +64,22 @@ impl AuthBackend for Ldap {
         }
 
         // find user dn
+        let filter = self.search_filter(username);
         let (results, _res) = ldap.search(
             self.config.base_dn.as_str(),
             self.config.scope.clone().into(),
-            format!(
-                "(&({}={}){})",
-                ldap_escape(&self.config.login_attribute),
-                ldap_escape(username),
-                self.config.filter
-            ).as_str(),
+            filter.as_str(),
             attrs,
         ).await?.success()?;
-        ldap.unbind().await?;
 
         if results.is_empty() {
-            bail!("no users found");
+            bail!("no users found with filter '{}'", filter);
         }
 
         let user = SearchEntry::construct(results[0].clone());
 
+        // verify credentials by rebinding as the found user,
+        // before unbind: unbind terminates the connection
         ldap.simple_bind(
             user.dn.as_str(),
             password,
@@ -96,5 +113,42 @@ impl AuthBackend for Ldap {
                 additional_data: None,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend(filter: &str) -> Ldap {
+        Ldap {
+            config: ldap::Ldap {
+                filter: filter.to_string(),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn filter_is_combined_with_login_attribute() {
+        assert_eq!(
+            backend("(objectClass=inetOrgPerson)").search_filter("alice"),
+            "(&(uid=alice)(objectClass=inetOrgPerson))",
+        );
+    }
+
+    #[test]
+    fn empty_filter_matches_login_attribute_only() {
+        assert_eq!(backend("").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("  ").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("()").search_filter("alice"), "(uid=alice)");
+    }
+
+    #[test]
+    fn username_is_escaped() {
+        assert_eq!(
+            backend("").search_filter("a*)(uid=*"),
+            "(uid=a\\2a\\29\\28uid=\\2a)",
+        );
     }
 }

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -36,10 +36,10 @@ pub struct Ldap {
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
-            uri: "ldap://localhost:339".to_string(),
+            uri: "ldap://localhost:389".to_string(),
             scope: Scope::default(),
             base_dn: "".to_string(),
-            filter: "()".to_string(),
+            filter: "".to_string(),
             login_attribute: "uid".to_string(),
             bind: "".to_string(),
             password: "".to_string(),


### PR DESCRIPTION
## Problem

Fixes lixmal/keepass4web-rs#260 (LDAP server cannot work, user not found).

LDAP logins fail. Two distinct issues:

1. **`unbind()` before the credential check**: the search connection was unbound before re-binding as the found user. `unbind` terminates the connection in ldap3, so the user-password bind could never succeed — LDAP login was broken even with a correct configuration.
2. **Misleading "no users found" failures**: the configured `filter` is ANDed with the login attribute match (`(&(<login_attribute>=<username>)<filter>)`) and no placeholder substitution takes place. A filter containing a template placeholder (e.g. `(uid=%[1]s)` copied from other projects) is matched literally and silently matches nothing, with no way to see the final filter in the logs.

## Changes

- Re-bind as the found user **before** unbinding, on the still-open connection
- Check the result of the service account bind (`.success()`), so a failed admin bind is reported as such instead of surfacing as a confusing search error
- Reject empty passwords: an empty password results in an anonymous bind, which most LDAP servers report as success — bypassing the password check entirely (RFC 4513 §5.1.2)
- Build the search filter safely: an empty/whitespace filter now matches on the login attribute only; the invalid default filter `()` is removed
- Include the effective search filter in the "no users found" error so configuration mistakes are diagnosable from the logs
- Document the filter semantics in `config.yml`
- Fix the default LDAP port (`339` → `389`)

## Testing

- Added unit tests for the filter construction (combination with login attribute, empty filter handling, username escaping) — all pass
- `cargo test` compiles and passes in a `rust:1.83` container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken LDAP login by checking user credentials on the active connection before unbind and tightening validation to prevent anonymous binds. Also makes filter handling safe and debuggable.

- Bug Fixes
  - Rebind as the found user before unbind to actually verify the password.
  - Validate the service-account bind and surface bind failures clearly.
  - Reject empty passwords to block anonymous binds (RFC 4513 §5.1.2).
  - Build a safe search filter and log the effective filter when no users are found; empty/whitespace means “login-attribute only”; escape usernames.
  - Document filter semantics in `config.yml`.

- Migration
  - Ensure `LDAP.filter` has no placeholders; leave empty to match on the login attribute only.
  - Update configs to use port `389` and enforce non-empty passwords.

<sup>Written for commit b8a408d6e5bb064565e8cbff4adf1e28a5f73705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



