### PR TITLE
fix: correct broken log statement in embed_in_index

### DIFF
--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -344,7 +344,7 @@ async fn embed_in_index(success: bool, message: Option<String>, data: Option<Ses
     let mut index = match tokio::fs::read_to_string(INDEX_FILE).await {
         Ok(v) => v,
         Err(err) => {
-            info!("user login from '{}': ", err);
+            error!("failed to read index file: {}", err);
             return HttpResponse::InternalServerError().json(json!(
                 {
                     "success": false,


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#284.

## Problem
[route/auth.rs](https://github.com/allamiro/keepass4web-rs/blob/master/src/server/route/auth.rs#L347) logged `info!("user login from '{}': ", err)` — the error was interpolated where the username belongs and the actual error message was dropped, making index-file read failures undebuggable.

## Change
Log the failure as `error!("failed to read index file: {}", err)` — correct severity and the real cause.

## Testing
Full `cargo test` suite passes (9/9) in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect logging in embed_in_index that misattributed errors to a user login message. Now logs index file read failures at error level with the actual error message for easier debugging.

<sup>Written for commit 5757f7b0ab36ac792149e4356fa53918c1d6a25a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




