### PR TITLE
fix: error responses incorrectly reported success: true

### DIFF
--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -191,7 +191,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         error!("db login from '{}': failed to store key: {}", username, err);
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store key",
             }
         ));
@@ -204,7 +204,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         }
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store db",
             }
         ));
@@ -221,7 +221,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
 fn get_user_info(session: &Session) -> Result<UserInfo, HttpResponse> {
     let resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to retrieve session",
         }
     ));

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -66,7 +66,7 @@ pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow
 pub(crate) async fn _close_db(session: &Session, config: &Config, db_cache: &DbCache) -> Result<(), HttpResponse> {
     let err_resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to close db",
         }
     ));


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#280.

## Problem
Four error responses carried `"success": true`, so API clients could interpret hard failures as success:

- `db_login` 'failed to store key'
- `db_login` 'failed to store db'
- `get_user_info` 'failed to retrieve session'
- `_close_db` 'failed to close db'

## Change
All four now return `"success": false`. No other behavior change.

## Testing
Full `cargo test` suite passes (9/9) in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed four error responses that incorrectly returned "success": true, so clients now correctly detect failures. All affected paths now return "success": false with no other behavior changes.

- **Bug Fixes**
  - db_login: "failed to store key"
  - db_login: "failed to store db"
  - get_user_info: "failed to retrieve session"
  - _close_db: "failed to close db"

<sup>Written for commit 44459888b28991fb216da5aab7adcca46a8d7046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




