### PR TITLE
feat: turnkey compose environment for testing the LDAP and OIDC auth backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment for the optional auth test services in docker-compose.yml.
+# Copy to .env (docker compose loads it automatically) and adjust as needed:
+#   cp .env.example .env
+# These are throwaway example values for local testing only.
+
+### OpenLDAP (auth_backend: LDAP) ###
+LDAP_ROOT=dc=example,dc=org
+LDAP_ADMIN_USERNAME=admin
+LDAP_ADMIN_PASSWORD=adminpassword
+LDAP_TEST_USER=testuser
+LDAP_TEST_PASSWORD=testpass
+
+### Keycloak (auth_backend: OIDC) ###
+# admin console login at http://localhost:8081
+KC_ADMIN_USERNAME=admin
+KC_ADMIN_PASSWORD=admin
+# pre-provisioned by tests/keycloak/realm.json (imported on startup):
+# realm 'keepass', client 'keepass4web' with this secret, and a test user
+# 'testuser' / 'testpass'
+OIDC_CLIENT_ID=keepass4web
+OIDC_CLIENT_SECRET=insecure-example-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ public/fonts/*
 # data
 *.kdbx
 
+# local environment (copied from .env.example)
+.env
+
 # jetbrains
 .idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,67 @@ services:
       - ./tests/test.kdbx:/db.kdbx
     security_opt:
       - seccomp=seccomp/keyring.json
+
+  ### Optional auth backends for testing ###
+  #
+  # The services below are disabled by default. To enable one:
+  #   1. cp .env.example .env   (example credentials, adjust if you like)
+  #   2. remove the leading '#' from the service block you need
+  #      (openldap for auth_backend: LDAP, keycloak for auth_backend: OIDC)
+  #   3. update config.yml as shown below, then: docker compose up -d
+  #
+  # --- OpenLDAP (auth_backend: LDAP) ---
+  #
+  # Seeded with the LDAP_TEST_USER / LDAP_TEST_PASSWORD user from .env.
+  # Matching config.yml settings (with the .env.example defaults):
+  #
+  #   auth_backend: 'LDAP'
+  #   LDAP:
+  #     uri: 'ldap://openldap:1389'        # 'ldap://127.0.0.1:1389' when running the app outside compose
+  #     scope: 'subtree'
+  #     base_dn: 'ou=users,dc=example,dc=org'
+  #     filter: '(objectClass=inetOrgPerson)'
+  #     login_attribute: 'uid'
+  #     bind: 'cn=admin,dc=example,dc=org'
+  #     password: 'adminpassword'
+  #
+  #openldap:
+  #  image: docker.io/bitnamilegacy/openldap:2.6
+  #  ports:
+  #    - "1389:1389"
+  #  environment:
+  #    - LDAP_ROOT=${LDAP_ROOT}
+  #    - LDAP_ADMIN_USERNAME=${LDAP_ADMIN_USERNAME}
+  #    - LDAP_ADMIN_PASSWORD=${LDAP_ADMIN_PASSWORD}
+  #    - LDAP_USERS=${LDAP_TEST_USER}
+  #    - LDAP_PASSWORDS=${LDAP_TEST_PASSWORD}
+
+  # --- Keycloak (auth_backend: OIDC) ---
+  #
+  # The realm 'keepass' is imported automatically from tests/keycloak/realm.json:
+  # confidential client 'keepass4web' (secret in .env.example) with the redirect
+  # URI http://localhost:8080/callback_user_auth, and user 'testuser' / 'testpass'.
+  # Admin console: http://localhost:8081 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
+  # Matching config.yml settings (with the .env.example defaults):
+  #
+  #   auth_backend: 'OIDC'
+  #   OIDC:
+  #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
+  #     client_id: 'keepass4web'
+  #     client_secret: 'insecure-example-client-secret'
+  #     save_id_token: true
+  #     scopes:
+  #       - 'profile'
+  #
+  # Note: redirecting auth backends may require cookie_samesite: 'lax'.
+  #
+  #keycloak:
+  #  image: quay.io/keycloak/keycloak:26.0
+  #  command: start-dev --import-realm
+  #  ports:
+  #    - "8081:8080"
+  #  volumes:
+  #    - ./tests/keycloak:/opt/keycloak/data/import:ro
+  #  environment:
+  #    - KC_BOOTSTRAP_ADMIN_USERNAME=${KC_ADMIN_USERNAME}
+  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=${KC_ADMIN_PASSWORD}

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -1,0 +1,42 @@
+{
+  "realm": "keepass",
+  "enabled": true,
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "keepass4web",
+      "name": "KeePass4Web",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "insecure-example-client-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/callback_user_auth",
+        "http://127.0.0.1:8080/callback_user_auth"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "testuser@example.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #312.

## What
Optional `openldap` and `keycloak` services in docker-compose.yml for testing the LDAP and OIDC auth backends — disabled by default, enabled by removing the comment markers from the block you need. Matching config.yml snippets are documented inline.

- **`.env.example`** holds all example credentials (LDAP root/admin/test user, Keycloak admin, OIDC client id/secret); `cp .env.example .env` and compose picks it up automatically (`.env` is gitignored)
- **Keycloak is pre-provisioned**: `start-dev --import-realm` imports `tests/keycloak/realm.json` — realm `keepass`, confidential client `keepass4web` with the `/callback_user_auth` redirect URIs, and user `testuser`/`testpass`. OIDC is testable with zero admin-console setup
- **OpenLDAP** is seeded with the test user from `.env`

## Validation (all live)
- `docker compose config` resolves every variable from the example env
- Realm import verified: the `realms/keepass` discovery endpoint serves ~5s after start
- **Full OIDC flow end-to-end with curl**: app startup discovery → `/authenticated` returns the PKCE redirect → Keycloak login form → credential POST → 302 to `/callback_user_auth` → code exchange + ID-token validation → session established (`cn: testuser`)
- LDAP: `ldapsearch` confirms the seeded user; login flow verified earlier in this series
- Useful test infrastructure for #275, #276, #287