### PR TITLE
fix(ldap): case-insensitive attribute lookup, request login attribute in search

### DIFF
--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -8,6 +8,14 @@ use crate::config::ldap;
 
 const CN_ATTR: &str = "CN";
 
+// ldap attribute names are case-insensitive (RFC 4512), but servers return
+// them in their own canonical casing, e.g. openldap returns 'cn' for 'CN'
+fn get_attr_ci<'a>(attrs: &'a std::collections::HashMap<String, Vec<String>>, name: &str) -> Option<&'a Vec<String>> {
+    attrs.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v)
+}
+
 pub struct Ldap {
     pub(crate) config: ldap::Ldap,
 }
@@ -35,7 +43,7 @@ impl AuthBackend for Ldap {
             self.config.password.as_str(),
         ).await?;
 
-        let mut attrs = vec![CN_ATTR];
+        let mut attrs = vec![CN_ATTR, self.config.login_attribute.as_str()];
         if let Some(k) = &self.config.database_attribute {
             attrs.push(k);
         }
@@ -69,20 +77,20 @@ impl AuthBackend for Ldap {
         ).await?.success()?;
         ldap.unbind().await?;
 
-        let cn = user.attrs.get(CN_ATTR)
+        let cn = get_attr_ci(&user.attrs, CN_ATTR)
             .ok_or(anyhow!("CN attribute not found"))?;
-        let id = user.attrs.get(&self.config.login_attribute)
+        let id = get_attr_ci(&user.attrs, &self.config.login_attribute)
             .ok_or(anyhow!("login attribute '{}' not found", &self.config.login_attribute))?;
 
         let mut db_location = None;
         let mut keyfile_location = None;
         if let Some(key) = &self.config.database_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 db_location = Some(v[0].clone());
             }
         }
         if let Some(key) = &self.config.keyfile_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 keyfile_location = Some(v[0].clone());
             }
         }
@@ -96,5 +104,21 @@ impl AuthBackend for Ldap {
                 additional_data: None,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attribute_lookup_is_case_insensitive() {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("cn".to_string(), vec!["Test User".to_string()]);
+        attrs.insert("uID".to_string(), vec!["testuser".to_string()]);
+
+        assert_eq!(get_attr_ci(&attrs, "CN").unwrap()[0], "Test User");
+        assert_eq!(get_attr_ci(&attrs, "uid").unwrap()[0], "testuser");
+        assert!(get_attr_ci(&attrs, "mail").is_none());
     }
 }


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#292.

## Problem
Two related bugs broke LDAP login against OpenLDAP even with correct credentials:

1. Attribute lookups in the search result were case-sensitive. LDAP attribute names are case-insensitive (RFC 4512 §2.5) and servers return their own canonical casing — OpenLDAP returns `cn` for a requested `CN`, so login failed with 'CN attribute not found'.
2. The user search only requested the `CN` attribute, so the login attribute (e.g. `uid`) was never in the result and its lookup failed next ('login attribute uid not found').

## Changes
- `get_attr_ci()` helper for case-insensitive attribute lookup, used for CN, login attribute, database/keyfile attributes
- the search now requests the login attribute alongside CN
- unit test for the case-insensitive lookup

## Testing
- `cargo test`: 10/10 pass
- End-to-end against a seeded OpenLDAP 2.6 container (from the compose setup in PR #4): valid credentials → 200 + session, wrong password → 401 (`invalidCredentials` from user bind), empty password → rejected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix LDAP login failures by using case-insensitive attribute lookup and requesting the login attribute in the search. Restores compatibility with OpenLDAP and other servers that return canonical-cased attributes.

- **Bug Fixes**
  - Added get_attr_ci() and used it for CN, login, database, and keyfile attributes.
  - Search now requests CN plus the configured login attribute (e.g., uid).
  - Added a unit test for the case-insensitive lookup.

<sup>Written for commit 8743667ffb71ea3dae9c0b0f213ab305ccae29a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




