### PR TITLE
fix: get_file endpoint panicked via todo!(), return 501 instead

### DIFF
--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -230,12 +230,6 @@ impl KeePass {
         )
     }
 
-    pub fn get_file(&self, params: &Query<File>) -> Result<Vec<u8>> {
-        let _entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
-
-        todo!()
-    }
-
     pub fn search_entries(&self, params: &Query<SearchTerm>) -> Result<EntryGroup> {
         let mut term = params.term.clone();
         if !self.config.search.allow_regex {

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -133,26 +133,17 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
 
 #[get("/get_file")]
 async fn get_file(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Query<File>) -> impl Responder {
-    let keepass = match util::get_db(&session, &config, &db_cache).await {
-        Ok(v) => v,
-        Err(err) => return err,
+    if let Err(err) = util::get_db(&session, &config, &db_cache).await {
+        return err;
     };
 
-    let username = session.get_user_id();
-    let file = match keepass.get_file(&params) {
-        Ok(v) => v,
-        Err(err) => {
-            info!("{}: failed to get file '{}' of entry '{}': {}", username, params.filename, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get file",
-                }
-            ));
+    info!("{}: file download requested for '{}' of entry '{}', but it is not implemented", session.get_user_id(), params.filename, params.entry_id);
+    HttpResponse::NotImplemented().json(json!(
+        {
+            "success": false,
+            "message": "file download is not implemented yet",
         }
-    };
-
-    HttpResponse::Ok().body(file)
+    ))
 }
 
 #[get("/search_entries")]


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#272.

## Problem
`KeePass::get_file` was `todo!()`, exposed at `/api/v1/get_file` — any authenticated user requesting an entry attachment triggered a runtime panic in the handler.

## Change
- the handler now returns `501 Not Implemented` with a JSON error message (and logs the attempt) until attachment download is actually implemented
- the unimplemented `KeePass::get_file` is removed; the session/db checks still run first so the endpoint behaves consistently with the others

Actual attachment support remains future work (tracked alongside write support in lixmal/keepass4web-rs#273's roadmap).

## Testing
`cargo test`: 9/9 pass in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent runtime panic on `/api/v1/get_file` by returning 501 Not Implemented with a JSON error until attachments are supported. Removed the unimplemented `KeePass::get_file`; the route still runs session/db checks and now logs the request.

<sup>Written for commit ba435286c1ce5ba647cca14227216b153556a6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




