### PR TITLE
fix(http): fail on non-success response status codes

### DIFF
--- a/src/db_backend/http.rs
+++ b/src/db_backend/http.rs
@@ -32,7 +32,7 @@ impl DbBackend for Http {
     async fn get_db_read(&self, user_info: &UserInfo) -> Result<Pin<Box<dyn AsyncRead + '_>>> {
         let url = self.get_db_url(user_info)?;
 
-        let response = self.get_request(Method::GET, url)?.send().await?;
+        let response = self.get_request(Method::GET, url)?.send().await?.error_for_status()?;
         Ok(
             Self::get_boxed_response(response)
         )
@@ -62,7 +62,7 @@ impl DbBackend for Http {
             Err(err) => return Some(Err(err))
         };
 
-        match request.send().await {
+        match request.send().await.and_then(|r| r.error_for_status()) {
             Ok(response) => {
                 Some(Ok(Self::get_boxed_response(response)))
             }
@@ -81,7 +81,7 @@ impl DbBackend for Http {
 
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            tx.send(match req.send().await {
+            tx.send(match req.send().await.and_then(|r| r.error_for_status()) {
                 Ok(_) => Ok(()),
                 Err(err) => Err(err).map_err(Error::new),
             }) // ignore failed send
@@ -216,6 +216,38 @@ mod tests {
     #[tokio::test]
     async fn write_fail() {
         let res = write_http(Url::from_str("http://0.0.0.0").unwrap()).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/")
+            .with_body("<html>not found</html>")
+            .with_status(404)
+            .create_async().await;
+
+        let mut config = Config::default();
+        config.http.database_url = Some(Url::from_str(&server.url()).unwrap());
+        let http = Http::new(&config);
+        let res = http.get_db_read(&UserInfo::default()).await;
+
+        mock.assert_async().await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn write_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("PUT", "/")
+            .with_status(500)
+            .create_async().await;
+
+        let res = write_http(Url::from_str(&server.url()).unwrap()).await;
+
+        mock.assert_async().await;
 
         assert!(res.is_err());
     }


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#274.

## Problem
The HTTP db backend never checked response status codes. A 404/500 error page was streamed straight into the kdbx parser (reads) or silently treated as a successful upload (writes).

## Changes
- `get_db_read`, `get_key_read`: `error_for_status()` before streaming the body
- `get_db_write`: the upload result channel now reports non-success statuses as errors
- two new regression tests (GET 404, PUT 500), both fail before the fix

## Testing
`cargo test`: 11/11 pass in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the HTTP db backend fail on non-success status codes instead of streaming error pages or treating failed writes as successful. This prevents confusing parser errors and surfaces clear HTTP failures.

- **Bug Fixes**
  - Use `error_for_status()` in `get_db_read` and `get_key_read` before streaming.
  - Propagate non-2xx statuses as errors in `get_db_write`.
  - Add regression tests for GET 404 and PUT 500.

<sup>Written for commit 3c03e8073e6db2c2a16a4f45e6213fdc55418c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




