### PR TITLE
fix: 404 for missing entries/groups/icons, repair icon caching headers

### DIFF
--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -26,6 +26,19 @@ use crate::keepass::entry::{
 };
 use crate::keepass::key::SecretKey;
 
+// distinguishes missing entries/groups/icons from real server faults,
+// so handlers can return 404 instead of 500
+#[derive(Debug, Clone)]
+pub struct NotFoundError(pub &'static str);
+
+impl std::fmt::Display for NotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} not found", self.0)
+    }
+}
+
+impl std::error::Error for NotFoundError {}
+
 #[derive(Deserialize)]
 pub struct Id {
     pub id: Uuid,
@@ -169,7 +182,7 @@ impl KeePass {
     }
 
     pub fn get_group_entries(&self, params: &Query<Id>) -> Result<EntryGroup> {
-        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(anyhow!("group not found"))?;
+        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(NotFoundError("group"))?;
 
         let mut entries = Vec::with_capacity(group.children.len());
         for node in &group.children {
@@ -202,13 +215,13 @@ impl KeePass {
     }
 
     pub fn get_entry(&self, params: &Query<Id>) -> Result<Entry> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(NotFoundError("entry"))?;
 
         Ok(entry.into())
     }
 
     pub fn get_protected(&self, params: &Query<Protected>) -> Result<SecretString> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(NotFoundError("entry"))?;
 
         let field = match params.name.as_str() {
             "password" => entry.fields.get("Password").cloned(),
@@ -220,7 +233,7 @@ impl KeePass {
                 Value::Protected(p) => p,
                 _ => bail!("not a protected field"),
             },
-            None => bail!("field not found"),
+            None => return Err(NotFoundError("field").into()),
         };
 
         Ok(
@@ -261,7 +274,7 @@ impl KeePass {
             }
         }
 
-        bail!("icon not found")
+        Err(NotFoundError("icon").into())
     }
 
     pub(crate) fn find_all_groups(group: &keepass::db::Group) -> Group {

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -2,15 +2,28 @@ use actix_session::Session;
 use actix_web::{get, HttpResponse, Responder, web};
 use actix_web::web::Data;
 use log::info;
-use mime::IMAGE_PNG;
 use serde_json::json;
 use secrecy::ExposeSecret;
 
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
-use crate::keepass::keepass::{File, Id, Protected, SearchTerm};
+use crate::keepass::keepass::{File, Id, NotFoundError, Protected, SearchTerm};
 use crate::server::route::util;
 use crate::session::AuthSession;
+
+// 404 for missing entries/groups/icons, 500 for everything else
+fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
+    let resp = json!(
+        {
+            "success": false,
+            "message": message,
+        }
+    );
+    if err.downcast_ref::<NotFoundError>().is_some() {
+        return HttpResponse::NotFound().json(resp);
+    }
+    HttpResponse::InternalServerError().json(resp)
+}
 
 #[get("/get_groups")]
 async fn get_groups(session: Session, config: Data<Config>, db_cache: Data<DbCache>) -> impl Responder {
@@ -56,12 +69,7 @@ async fn get_group_entries(session: Session, config: Data<Config>, db_cache: Dat
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entries for group '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get group entries",
-                }
-            ));
+            return error_response(&err, "failed to get group entries");
         }
     };
 
@@ -85,12 +93,7 @@ async fn get_entry(session: Session, config: Data<Config>, db_cache: Data<DbCach
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entry '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get entry",
-                }
-            ));
+            return error_response(&err, "failed to get entry");
         }
     };
 
@@ -114,12 +117,7 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get protected '{}' of entry '{}': {}", username, params.name, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get protected field",
-                }
-            ));
+            return error_response(&err, "failed to get protected field");
         }
     };
 
@@ -201,22 +199,53 @@ async fn get_icon(session: Session, config: Data<Config>, db_cache: Data<DbCache
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get icon '{}': {}", username, params.id, err);
-            // TODO: Serve 404 if icon not found
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get icon",
-                }
-            ));
+            return error_response(&err, "failed to get icon");
         }
     };
 
     HttpResponse::Ok()
         // UUID is unique, cache this forever
-        .append_header(("Cache-Control", "max-age=31536000; public; s-max-age=31536000"))
+        .append_header(("Cache-Control", "public, max-age=31536000, s-maxage=31536000, immutable"))
         .append_header(("ETag", icon.uuid.to_string()))
-        // TODO: sniff content type?
-        .content_type(IMAGE_PNG)
+        .content_type(icon_mime(&icon.data))
         .body(icon.data.clone())
+}
+
+fn icon_mime(data: &[u8]) -> &'static str {
+    if data.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "image/png"
+    } else if data.starts_with(b"\xff\xd8\xff") {
+        "image/jpeg"
+    } else if data.starts_with(b"GIF8") {
+        "image/gif"
+    } else if data.starts_with(b"<svg") || data.starts_with(b"<?xml") {
+        "image/svg+xml"
+    } else {
+        // previous behavior, custom icons are usually png
+        "image/png"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_mime_detection() {
+        assert_eq!(icon_mime(b"\x89PNG\r\n\x1a\nrest"), "image/png");
+        assert_eq!(icon_mime(b"\xff\xd8\xff\xe0rest"), "image/jpeg");
+        assert_eq!(icon_mime(b"GIF89a"), "image/gif");
+        assert_eq!(icon_mime(b"<svg xmlns="), "image/svg+xml");
+        assert_eq!(icon_mime(b"unknown"), "image/png");
+    }
+
+    #[test]
+    fn not_found_maps_to_404() {
+        let err: anyhow::Error = NotFoundError("entry").into();
+        assert_eq!(error_response(&err, "msg").status(), 404);
+
+        let err = anyhow::anyhow!("other");
+        assert_eq!(error_response(&err, "msg").status(), 500);
+    }
 }
 


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#281, fixes lixmal/keepass4web-rs#282.

## Problem
- Requesting a non-existent entry/group/protected field/icon returned `500 Internal Server Error`, indistinguishable from real server faults (#282)
- The icon endpoint's `Cache-Control: max-age=31536000; public; s-max-age=31536000` is invalid (semicolons instead of commas, `s-max-age` instead of `s-maxage`) so browsers ignored it and re-fetched icons; content type was always `image/png` regardless of the data (#281)

## Changes
- new `NotFoundError` type in `keepass.rs`; lookups return it and handlers map it to 404 via a shared `error_response()` helper (resolves the existing 'Serve 404 if icon not found' TODO)
- icon Cache-Control fixed: `public, max-age=31536000, s-maxage=31536000, immutable`
- icon content type sniffed from magic bytes (PNG/JPEG/GIF/SVG, falling back to PNG — the previous behavior — for unknown data), resolving the 'sniff content type' TODO
- unit tests for the 404 mapping and mime sniffing

## Testing
`cargo test`: 11/11 pass (2 new) in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 for missing entries, groups, protected fields, and icons instead of 500. Fix icon caching headers and MIME detection so browsers cache icons correctly. Fixes #281 and #282.

- **Bug Fixes**
  - Added NotFoundError and a shared error_response to map not-found cases to 404.
  - Updated get_group_entries, get_entry, get_protected, and get_icon to use the new mapping.
  - Corrected icon Cache-Control to "public, max-age=31536000, s-maxage=31536000, immutable".
  - Sniff icon MIME type (PNG/JPEG/GIF/SVG) with PNG fallback; added tests for 404 mapping and MIME detection.

<sup>Written for commit fe86142c52702196f34fa7577633bfe42c8853f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




