### PR TITLE
fix: renew session on user login to prevent session fixation

### DIFF
--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -47,6 +47,9 @@ pub(crate) fn check_user_session(session: &Session, username: &str) -> Result<()
 }
 
 pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow::Result<CsrfToken> {
+    // rotate the session on privilege change to prevent session fixation
+    session.renew();
+
     if let Err(err) = session.insert(SESSION_KEY_USER, user_info) {
         session.destroy();
         error!("user login from '{}': {}", user_info.id, err);


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#277.

## Problem
`set_user_session` stored the authenticated user in the pre-login session without rotating it — standard session-fixation hygiene (actix-session provides `Session::renew()` exactly for privilege changes).

## Change
`session.renew()` is called at the start of `set_user_session`, so both the mask login path (`/user_login`) and the OIDC callback path get a fresh session key on successful authentication.

## Testing
`cargo test`: 9/9 pass in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotate the session on authentication to prevent session fixation. `set_user_session` now calls `Session::renew()` (from `actix-session`) before storing the user, so both `/user_login` and the OIDC callback issue a fresh session ID.

<sup>Written for commit 36a056d3f9942252e7fea4f4a6c682b903e34d60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




