### PR TITLE
feat: validate LDAP config at startup

### DIFF
--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -22,6 +22,10 @@ impl Ldap {
 
 #[async_trait]
 impl AuthBackend for Ldap {
+    fn validate_config(&self) -> Result<()> {
+        self.config.validate()
+    }
+
     fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -1,4 +1,6 @@
+use anyhow::{bail, Result};
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Clone, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -33,6 +35,28 @@ pub struct Ldap {
     pub keyfile_attribute: Option<String>,
 }
 
+impl Ldap {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.uri.trim().is_empty() {
+            bail!("LDAP: uri must be specified");
+        }
+        match Url::parse(&self.uri) {
+            Ok(url) => match url.scheme() {
+                "ldap" | "ldaps" | "ldapi" => {}
+                scheme => bail!("LDAP: unsupported uri scheme '{}', expected ldap, ldaps or ldapi", scheme),
+            },
+            Err(err) => bail!("LDAP: invalid uri '{}': {}", self.uri, err),
+        }
+        if self.base_dn.trim().is_empty() {
+            bail!("LDAP: base_dn must be specified");
+        }
+        if self.login_attribute.trim().is_empty() {
+            bail!("LDAP: login_attribute must be specified");
+        }
+        Ok(())
+    }
+}
+
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
@@ -46,5 +70,49 @@ impl Default for Ldap {
             database_attribute: None,
             keyfile_attribute: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> Ldap {
+        Ldap {
+            base_dn: "ou=users,dc=example,dc=org".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        assert!(valid().validate().is_ok());
+
+        let mut ldaps = valid();
+        ldaps.uri = "ldaps://example.org:636".to_string();
+        assert!(ldaps.validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_config_fails() {
+        let mut c = valid();
+        c.uri = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "http://example.org".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "not a url".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.base_dn = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.login_attribute = " ".to_string();
+        assert!(c.validate().is_err());
     }
 }


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#287.

## Problem
Unlike OIDC/htpasswd/Filesystem, the LDAP backend had no `validate_config()`. Empty `uri`/`base_dn`/`login_attribute` or a wrong uri scheme passed startup silently and only failed at login time — where backend errors are shown to users as 'username or password incorrect' (see lixmal/keepass4web-rs#260 / #276 for how painful that is to debug).

## Changes
- `config::ldap::Ldap::validate()`: requires non-empty `uri` (parseable, scheme `ldap`/`ldaps`/`ldapi`), `base_dn`, `login_attribute`
- LDAP auth backend implements `validate_config()`, so a misconfigured server now refuses to start with a clear message
- unit tests for valid and invalid configs

## Testing
`cargo test`: 11/11 pass (2 new) in a rust:1.83 container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-fast LDAP config validation at startup to prevent silent misconfigurations and confusing login errors. Startup now rejects empty or invalid `uri`, `base_dn`, or `login_attribute` with clear messages.

- **New Features**
  - Implemented `validate_config()` in the LDAP backend.
  - Validate `uri` is parseable and uses `ldap`/`ldaps`/`ldapi`; require non-empty `base_dn` and `login_attribute`.
  - Added unit tests for valid and invalid configs.

<sup>Written for commit 55a5c62f9c7f21bf771e398458f7700403c9621a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




