### PR TITLE
fix: evict expired entries from DbCache

### DIFF
--- a/src/keepass/db_cache.rs
+++ b/src/keepass/db_cache.rs
@@ -43,15 +43,19 @@ impl Deref for DbCache {
 
 impl DbCache {
     pub async fn store(&self, session: &Session, enc_db: Encrypted) -> Result<()> {
-        self.write().await
-            .insert(
-                self.get_user(session)?, enc_db,
-            );
+        let user = self.get_user(session)?;
+        let mut cache = self.write().await;
+
+        // evict expired entries opportunistically, so the cache
+        // doesn't grow unboundedly with inactive users
+        let now = Instant::now();
+        cache.retain(|_, enc| now < enc.expiry);
+
+        cache.insert(user, enc_db);
 
         Ok(())
     }
 
-    // TODO: expire old entries periodically
     pub async fn retrieve(&self, session: &Session, timeout: Duration) -> Result<Encrypted> {
         let user = self.get_user(session)?;
         let mut enc = self.read().await.get(user.as_str()).ok_or(anyhow!("enc db not found in store"))?.clone();
@@ -82,5 +86,35 @@ impl DbCache {
         Ok(
             session.get::<UserInfo>(SESSION_KEY_USER)?.ok_or(anyhow!("unable to retrieve user from session"))?.id
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_session::SessionExt;
+    use actix_web::test::TestRequest;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn expired_entries_are_evicted_on_store() {
+        let cache = DbCache::default();
+        let req = TestRequest::default().to_http_request();
+        let session = req.get_session();
+        session.insert(SESSION_KEY_USER, UserInfo {
+            id: "alice".to_string(),
+            ..Default::default()
+        }).unwrap();
+
+        // expired entry of an inactive user
+        let (_, expired) = Encrypted::encrypt(vec![1, 2, 3], &[], Duration::from_secs(0)).unwrap();
+        cache.write().await.insert("bob".to_string(), expired);
+
+        let (_, fresh) = Encrypted::encrypt(vec![4, 5, 6], &[], Duration::from_secs(60)).unwrap();
+        cache.store(&session, fresh).await.unwrap();
+
+        let entries = cache.read().await;
+        assert!(entries.contains_key("alice"));
+        assert!(!entries.contains_key("bob"));
     }
 }


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#283.

## Problem
`DbCache` checked expiry on retrieval but never removed expired entries (long-standing TODO). With many users, encrypted databases of users who simply walked away accumulated in memory forever.

## Change
`store()` now evicts all expired entries (one `retain` under the already-held write lock) before inserting. Eviction is opportunistic — any login or expiry refresh cleans the map — which avoids a background task while bounding growth to active users.

## Testing
`cargo test`: 10/10 pass, including a new test that verifies an expired entry is dropped on the next store.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evicts expired entries from `DbCache` on store to stop unbounded growth from inactive users. Keeps memory bounded without a background task.

- **Bug Fixes**
  - Drop all expired entries under the existing write lock before inserting the new value (opportunistic eviction with `retain`).
  - Add a test verifying an expired entry is removed on the next store.

<sup>Written for commit 8dc021aa48332479eeda48972986593dc0fb1997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




