### PR TITLE
refactor: remove pointless zero padding in Encrypted

### DIFF
--- a/src/keepass/encrypted.rs
+++ b/src/keepass/encrypted.rs
@@ -9,8 +9,6 @@ use zeroize::Zeroize;
 
 use crate::keepass::key::SecretKey;
 
-const LENGTH_IV: usize = 16;
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Encrypted {
     data: Vec<u8>,
@@ -20,8 +18,7 @@ pub struct Encrypted {
 }
 
 impl Encrypted {
-    pub fn encrypt(mut input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
-        input.extend([0; LENGTH_IV]);
+    pub fn encrypt(input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
         let iv = Aes256Gcm::generate_nonce(&mut thread_rng()); // 96-bits; unique per message
         let mut enc = Encrypted {
             data: input,
@@ -42,7 +39,7 @@ impl Encrypted {
         let cipher = Aes256Gcm::new(key);
         cipher.decrypt_in_place(Nonce::from_slice(&self.iv), aad, &mut self.data)?;
 
-        let v = self.data[0..self.data.len() - LENGTH_IV].to_vec();
+        let v = self.data.clone();
         self.data.zeroize();
         Ok(SecretVec::new(v))
     }


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#286.

## Problem
`Encrypted::encrypt` appended 16 zero bytes to the plaintext and `decrypt` stripped the last 16 bytes again. AES-GCM needs no padding, and the `LENGTH_IV = 16` constant didn't even match the real 96-bit GCM nonce — the code only worked because both sides applied the same offset. Confusing for anyone auditing the crypto.

## Change
Padding and the misleading constant removed; `decrypt` returns the full plaintext. The format only lives in the in-memory `DbCache` (never persisted), so there are no compatibility concerns.

## Testing
`cargo test`: 9/9 pass, including the encryption roundtrip and full database roundtrip tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove pointless zero padding in `Encrypted` AES-GCM to simplify the logic and avoid offset bugs. `decrypt` now returns the full plaintext; `LENGTH_IV` is removed, and this only affects in-memory `DbCache` (no compatibility impact).

- **Refactors**
  - Stop appending/removing 16 zero bytes; GCM needs no padding.
  - Remove misleading `LENGTH_IV` constant (nonce remains 96-bit as before).

<sup>Written for commit 8635445739b8f4046803822f6b42502a52ed79ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




