### PR TITLE
feat: add security headers to all responses

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,7 +1,7 @@
 use actix_session::{config::PersistentSession, SessionMiddleware, storage::CookieSessionStore};
 use actix_web::{App, HttpServer, web};
 use actix_web::cookie::time::Duration;
-use actix_web::middleware::Logger;
+use actix_web::middleware::{DefaultHeaders, Logger};
 use anyhow::Result;
 use env_logger::Env;
 
@@ -45,6 +45,16 @@ impl Server {
                         .build(),
                 )
                 .wrap(Logger::default())
+                // registered last = outermost, so the headers are also set on
+                // responses short-circuited by the middlewares above.
+                // CSP is omitted for now: the index page relies on
+                // inline script injection (see embed_in_index)
+                .wrap(
+                    DefaultHeaders::new()
+                        .add(("X-Frame-Options", "DENY"))
+                        .add(("X-Content-Type-Options", "nosniff"))
+                        .add(("Referrer-Policy", "no-referrer"))
+                )
                 .configure(setup_routes)
         }).bind((server, port))?
             .run()


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#279.

## Change
Adds `DefaultHeaders` middleware setting on every response:

- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: no-referrer`

The middleware is registered last (= outermost in actix's reverse wrap order), which matters: responses short-circuited by the auth middleware would otherwise bypass it — verified during testing.

`Content-Security-Policy` is deliberately left out for now: `embed_in_index` injects an inline `<script>` into the index page, so a meaningful CSP needs frontend changes first (nonce or postMessage approach). Can be tracked separately.

## Testing
- `cargo test`: 9/9 pass
- Live verification with curl: all three headers present on a short-circuited 401 (the case the naive middleware ordering misses)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add default security headers to all HTTP responses using `actix_web` `DefaultHeaders`. Middleware is registered outermost so short-circuited responses also include them; CSP is deferred due to an inline script in the index.

- **New Features**
  - Add X-Frame-Options: DENY, X-Content-Type-Options: nosniff, Referrer-Policy: no-referrer on every response.
  - Register `DefaultHeaders` last to cover auth 401s and other short-circuits.

<sup>Written for commit 4c4b0f26343c48d6d4f6c6ee10f07f3c67bf3730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




