### PR TITLE
fix: normalize htpasswd user id to lowercase

### DIFF
--- a/src/auth_backend.rs
+++ b/src/auth_backend.rs
@@ -66,7 +66,9 @@ pub trait AuthBackend: Send + Sync {
 
     fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
 
-    //  TODO: handle case sensitivity
+    // backends returning case-insensitive user names must lowercase
+    // UserInfo.id: it keys the db cache (see ldap/htpasswd). OIDC subjects
+    // are case-sensitive opaque strings and are used as-is.
     async fn login(&self, _username: &str, _password: &str) -> Result<UserInfo> {
         bail!("login method not supported")
     }

--- a/src/auth_backend/htpasswd.rs
+++ b/src/auth_backend/htpasswd.rs
@@ -48,7 +48,8 @@ impl AuthBackend for Htpasswd {
 
         Ok(
             UserInfo {
-                id: username.to_owned(),
+                // lowercase like the ldap backend, the id keys the db cache
+                id: username.to_lowercase(),
                 name: username.to_owned(),
                 db_location: None,
                 keyfile_location: None,


### PR DESCRIPTION
Fixes lixmal/keepass4web-rs#278.

## Problem
`UserInfo.id` keys the in-memory `DbCache`, but backends normalized it inconsistently: LDAP lowercases, htpasswd didn't. Case variations of the same user produced duplicate cache entries (and inconsistent log identities).

## Changes
- htpasswd backend lowercases the id (display name keeps the typed casing), matching LDAP — this also resolves the 'handle case sensitivity' TODO on the trait
- OIDC is deliberately untouched: OIDC `sub` values are case-sensitive opaque strings per spec, lowercasing could merge distinct users; this is now documented on the `AuthBackend` trait

## Testing
`cargo test`: 9/9 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercases htpasswd user IDs to match LDAP and prevent duplicate DB cache entries and inconsistent log identities. Documents that OIDC `sub` stays case-sensitive and unchanged.

- **Bug Fixes**
  - Htpasswd now lowercases `UserInfo.id`; display `name` keeps original casing.
  - Added trait docs: case-insensitive backends must lowercase IDs; OIDC subjects are used as-is.

<sup>Written for commit 3467525acd8175ee307a93859919f7919d268f07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/keepass4web-rs/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




