### PR TITLE
feat: OIDC Docker split-brain fix, auto-create KDBX, entry CRUD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment for the optional auth test services in docker-compose.yml.
+# Copy to .env (docker compose loads it automatically) and adjust as needed:
+#   cp .env.example .env
+# These are throwaway example values for local testing only.
+
+### OpenLDAP (auth_backend: LDAP) ###
+LDAP_ROOT=dc=example,dc=org
+LDAP_ADMIN_USERNAME=admin
+LDAP_ADMIN_PASSWORD=adminpassword
+LDAP_TEST_USER=testuser
+LDAP_TEST_PASSWORD=testpass
+
+### Keycloak (auth_backend: OIDC) ###
+# admin console login at http://localhost:8081
+KC_ADMIN_USERNAME=admin
+KC_ADMIN_PASSWORD=admin
+# pre-provisioned by tests/keycloak/realm.json (imported on startup):
+# realm 'keepass', client 'keepass4web' with this secret, and a test user
+# 'testuser' / 'testpass'
+OIDC_CLIENT_ID=keepass4web
+OIDC_CLIENT_SECRET=insecure-example-client-secret

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ LDAP_TEST_USER=testuser
 LDAP_TEST_PASSWORD=testpass
 
 ### Keycloak (auth_backend: OIDC) ###
-# admin console login at http://localhost:8081
+# admin console login at http://localhost:8180
 KC_ADMIN_USERNAME=admin
 KC_ADMIN_PASSWORD=admin
 # pre-provisioned by tests/keycloak/realm.json (imported on startup):

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Packages
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
@@ -37,6 +43,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # gate on the bug-catching lint groups; style lints are not enforced yet
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious
+
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
       RUST_BACKTRACE: full
     steps:
       - uses: actions/checkout@v5
@@ -34,8 +33,6 @@ jobs:
   frontend-e2e:
     name: Frontend E2E Tests
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ public/fonts/*
 # data
 *.kdbx
 
+# local environment (copied from .env.example)
+.env
+
 # jetbrains
 .idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,12 +388,6 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -557,24 +551,13 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq 0.1.5",
-]
-
-[[package]]
-name = "blake2b_simd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
- "constant_time_eq 0.3.1",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -790,15 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
-name = "clippy"
-version = "0.0.302"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,12 +800,6 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -902,15 +870,6 @@ name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crypto-bigint"
@@ -1110,17 +1069,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1412,17 +1360,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -1430,7 +1367,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1911,7 +1848,7 @@ dependencies = [
  "getrandom 0.2.10",
  "hex-literal",
  "hmac 0.12.1",
- "rust-argon2 2.0.0",
+ "rust-argon2",
  "salsa20",
  "secstr",
  "serde",
@@ -1936,8 +1873,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "clap",
- "clippy",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
  "env_logger",
  "futures",
  "futures-util",
@@ -2145,7 +2081,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2397,7 +2333,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2607,28 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2 0.8.3",
 ]
 
 [[package]]
@@ -2767,25 +2686,13 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd 0.5.11",
- "constant_time_eq 0.1.5",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rust-argon2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e71971821b3ae0e769e4a4328dbcb517607b434db7697e9aba17203ec14e46a"
 dependencies = [
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
- "constant_time_eq 0.3.1",
+ "blake2b_simd",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -3322,17 +3229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs",
- "winapi",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,12 +3520,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ regex = "1.10.2"
 mime = "0.3.17"
 aes-gcm = { version = "0.10.3", features = ["zeroize", "std"] }
 constant_time_eq = "0.3.1"
-linux-keyutils = { version = "0.2.4", features = ["std"] }
 url = { version = "2.5.0", features = ["serde"] }
 openidconnect = "3.4.0"
 async-trait = "0.1.77"
@@ -42,6 +41,9 @@ reqwest = { version = "0.11.27", features = ["rustls", "__tls", "rustls-tls", "s
 futures = "0.3.31"
 futures-util = { version = "0.3.30", default-features = false, features = ["io"] }
 htpasswd-verify = { git = "https://github.com/twistedfall/htpasswd-verify", rev = "ff14703083cbd639f7d05622b398926f3e718d61" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-keyutils = { version = "0.2.4", features = ["std"] }
 
 [dev-dependencies]
 mockito = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,4 @@ futures-util = { version = "0.3.30", default-features = false, features = ["io"]
 htpasswd-verify = { git = "https://github.com/twistedfall/htpasswd-verify", rev = "ff14703083cbd639f7d05622b398926f3e718d61" }
 
 [dev-dependencies]
-clippy = "0.0.302"
 mockito = "1.7.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,17 @@ RUN npm install
 RUN cp node_modules/bootstrap/fonts/* public/fonts/
 RUN npm run build
 
-COPY src src
-COPY Cargo.* ./
-
 RUN apk add --no-cache build-base
-ENV RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
-RUN cargo build --bins --release
+
+# build dependencies in their own layer, so source changes don't recompile them
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src \
+    && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
+
+COPY src src
+RUN touch src/main.rs && cargo build --bins --release
 
 
 FROM scratch
@@ -31,6 +36,9 @@ VOLUME /conf
 
 USER 1000:1000
 
-ENV RUST_BACKTRACE=1;
+ENV RUST_BACKTRACE=1
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD ["/keepass4web", "--config", "/conf/config.yml", "--health-check"]
 
 CMD [ "/keepass4web", "--config", "/conf/config.yml"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   - [CONFIGURATION](#configuration)
   - [DEPLOYMENT](#deployment)
     - [Container](#container)
+    - [Docker Compose — htpasswd (default)](#docker-compose--htpasswd-default)
+    - [Docker Compose — LDAP (OpenLDAP)](#docker-compose--ldap-openldap)
+    - [Docker Compose — OIDC (Keycloak)](#docker-compose--oidc-keycloak)
     - [Classic](#classic)
   - [BACKENDS](#backends)
     - [Authentication Backends](#authentication-backends)
@@ -72,7 +75,12 @@ The minified, bundled file will be written to public/scripts/bundle.js
 
 ## CONFIGURATION
 
-- See `config.yml`
+Copy `config.example.yml` to `config.yml` and edit as needed. The example file contains
+ready-to-use snippets for every supported backend, with values that match the bundled
+docker-compose test services so you can test any backend with minimal changes.
+
+The default `config.yml` uses htpasswd authentication. See `config.example.yml` for
+LDAP and OIDC examples and documentation of every option.
 
 ## DEPLOYMENT
 
@@ -129,35 +137,111 @@ Example podman:
 
 (master password: `test`)
 
+> **Docker Desktop on macOS / Windows:** the kernel keyring syscalls are blocked by default.
+> Set `use_keyring: false` in `config.yml` to use the in-memory key store instead.
 
-### Docker Compose
+### Docker Compose — htpasswd (default)
 
-For easier deployment, you can use Docker Compose file
+The bundled `docker-compose.yml` starts the app with local htpasswd authentication:
 
-Then, to start the container run:
+```bash
+# 1. Create a password file (bcrypt)
+htpasswd -cB .htpasswd <username>
 
-
-```
+# 2. Start the stack
 docker-compose up -d
-
 ```
 
-To stop the container:
+App is available at <http://localhost:8080> (KeePass master password: `test`).
 
-```
+To stop:
+
+```bash
 docker-compose down
 ```
 
+### Docker Compose — LDAP (OpenLDAP)
+
+The repo ships a pre-configured OpenLDAP test service. Enable it with these steps:
+
+```bash
+# 1. Copy example credentials (safe defaults for local testing)
+cp .env.example .env
+
+# 2. Uncomment the 'openldap' service block in docker-compose.yml
+
+# 3. Switch config.yml to LDAP — replace auth_backend and add the LDAP block:
+cat >> config.yml <<'EOF'
+
+auth_backend: 'LDAP'
+LDAP:
+  uri: 'ldap://openldap:1389'
+  scope: 'subtree'
+  base_dn: 'ou=users,dc=example,dc=org'
+  filter: '(objectClass=inetOrgPerson)'
+  login_attribute: 'uid'
+  bind: 'cn=admin,dc=example,dc=org'
+  password: 'adminpassword'
+EOF
+
+# 4. Start the stack
+docker-compose up -d
+```
+
+Log in with the test user defined in `.env` (`LDAP_TEST_USER` / `LDAP_TEST_PASSWORD`,
+defaults `testuser` / `testpass`).
+
+For a full LDAP config reference including Active Directory and per-user database
+attributes see `config.example.yml`.
+
+### Docker Compose — OIDC (Keycloak)
+
+The repo ships a Keycloak instance with a pre-imported realm (`keepass`) and a
+pre-configured client (`keepass4web`). Enable it with these steps:
+
+```bash
+# 1. Copy example credentials (safe defaults for local testing)
+cp .env.example .env
+
+# 2. Uncomment the 'keycloak' service block in docker-compose.yml
+
+# 3. Switch config.yml to OIDC — replace auth_backend and add the OIDC block:
+cat >> config.yml <<'EOF'
+
+auth_backend: 'OIDC'
+OIDC:
+  issuer: 'http://keycloak:8180/realms/keepass'
+  client_id: 'keepass4web'
+  client_secret: 'insecure-example-client-secret'
+  save_id_token: true
+  scopes:
+    - 'profile'
+
+# OIDC redirect flow requires lax cookie policy
+cookie_samesite: 'lax'
+EOF
+
+# 4. Start the stack (Keycloak takes ~30 s to start)
+docker-compose up -d
+```
+
+- App: <http://localhost:8080> — log in with `testuser` / `testpass`
+- Keycloak admin console: <http://localhost:8180> — credentials from `.env`
+  (`KC_ADMIN_USERNAME` / `KC_ADMIN_PASSWORD`, defaults `admin` / `admin`)
+
+For a full OIDC config reference see `config.example.yml`.
+
+> **Note:** if you run the app outside docker-compose, replace `keycloak` in the
+> issuer URL with `localhost`: `http://localhost:8180/realms/keepass`.
+
 ### Classic
 
-This requires rust installed, compile the binary:
+This requires rust installed. Compile and run the binary:
 
-    export RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
-    cargo build --bins --release --target-dir release
-
-Run the binary:
-
-    target/release/keepass4web-rs
+```bash
+cargo build --bins --release
+./target/release/keepass4web-rs
+```
 
 ## BACKENDS
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -98,16 +98,16 @@ htpasswd:
 # uncomment the 'keycloak:' block in docker-compose.yml)
 #
 # Pre-provisioned: client 'keepass4web', user testuser / testpass.
-# Admin console:   http://localhost:8081  (KC_ADMIN_USERNAME/PASSWORD from .env)
+# Admin console:   http://localhost:8180  (KC_ADMIN_USERNAME/PASSWORD from .env)
 #
 # To use: set auth_backend: 'OIDC', fill in your real values below.
 # Note: OIDC redirect requires cookie_samesite: 'lax' (see below).
 # ──────────────────────────────────────────────────────────────
 # OIDC:
 #     # Issuer URL (the OpenID Connect discovery endpoint is <issuer>/.well-known/openid-configuration)
-#     # docker-compose service:          http://keycloak:8080/realms/keepass
-#     # running the app outside compose: http://localhost:8081/realms/keepass
-#     issuer: 'http://keycloak:8080/realms/keepass'
+#     # docker-compose service and outside compose: http://keycloak:8180/realms/keepass
+#     # (Keycloak runs on port 8180; keepass app is on 8080)
+#     issuer: 'http://keycloak:8180/realms/keepass'
 #
 #     client_id: 'keepass4web'
 #     client_secret: 'insecure-example-client-secret'

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,175 @@
+##############################################################
+### config.example.yml — copy-and-edit reference            ###
+###                                                          ###
+### Values for LDAP and OIDC match the test services in     ###
+### docker-compose.yml / .env.example exactly.  Enable the  ###
+### matching service in docker-compose.yml, set             ###
+### auth_backend below, and the app will work immediately.  ###
+###                                                          ###
+### For production deployments replace every value that     ###
+### says "example", "test", or "insecure" with your own.    ###
+##############################################################
+
+# Where to get KeePass databases from.
+# Available: Filesystem, HTTP
+db_backend: 'Filesystem'
+
+# Authentication backend — pick ONE, configure its section below.
+# Available: None, htpasswd, LDAP, OIDC
+#
+#   None     — no authentication (single-user / trusted-network only)
+#   htpasswd — local password file (bcrypt); good for small teams
+#   LDAP     — OpenLDAP / Active Directory
+#   OIDC     — OpenID Connect (Keycloak, Authentik, Azure AD, …)
+#
+auth_backend: 'htpasswd'
+
+
+### Database backends ###
+
+# db_backend: Filesystem
+Filesystem:
+    db_location: './db.kdbx'
+    # optional key file — storing key files on the server is not recommended
+    # keyfile_location: './db.key'
+
+# db_backend: HTTP  (fetch database over HTTP/HTTPS)
+# HTTP:
+#     database_url: 'https://files.example.com/db.kdbx'
+#     # keyfile_url: 'https://files.example.com/db.key'
+#     # credentials:
+#     #   username: 'fileuser'
+#     #   password: 'filepassword'
+#     # bearer: 'token-here'
+
+
+### Authentication backends ###
+
+# auth_backend: htpasswd
+# Create .htpasswd with: htpasswd -cB .htpasswd <username>
+htpasswd:
+    path: '.htpasswd'
+
+
+# ──────────────────────────────────────────────────────────────
+# LDAP example — matches the docker-compose OpenLDAP test service
+# (bitnami/openldap, seeded via LDAP_TEST_USER / LDAP_TEST_PASSWORD
+# from .env.example; uncomment the 'openldap:' block in docker-compose.yml)
+#
+# To use: set auth_backend: 'LDAP', fill in your real values below.
+# ──────────────────────────────────────────────────────────────
+# LDAP:
+#     # LDAP server URI
+#     # docker-compose service: ldap://openldap:1389
+#     # running the app outside compose: ldap://127.0.0.1:1389
+#     uri: 'ldap://openldap:1389'
+#
+#     # search scope: subtree (all sub-nodes), one (immediate children), base
+#     scope: 'subtree'
+#
+#     # search base distinguished name
+#     base_dn: 'ou=users,dc=example,dc=org'
+#
+#     # extra filter combined with the login attribute match:
+#     #   (&(<login_attribute>=<username>)<filter>)
+#     # leave empty to match on the login attribute only
+#     filter: '(objectClass=inetOrgPerson)'
+#
+#     # attribute used for login (must be unique per user)
+#     # Active Directory:  sAMAccountName  or  userPrincipalName
+#     # OpenLDAP / 389 DS: uid
+#     login_attribute: 'uid'
+#
+#     # DN and password for the read-only bind used to search the directory
+#     # (leave empty for anonymous bind if your LDAP allows it)
+#     bind: 'cn=admin,dc=example,dc=org'
+#     password: 'adminpassword'
+#
+#     # optional: per-user KeePass database / key file locations
+#     # stored as LDAP attributes on the user object
+#     # leave commented out to use the static Filesystem/HTTP location above
+#     # database_attribute: 'keePass'
+#     # keyfile_attribute:  'keePassKeyFile'
+
+
+# ──────────────────────────────────────────────────────────────
+# OIDC example — matches the docker-compose Keycloak test service
+# (realm 'keepass' auto-imported from tests/keycloak/realm.json;
+# uncomment the 'keycloak:' block in docker-compose.yml)
+#
+# Pre-provisioned: client 'keepass4web', user testuser / testpass.
+# Admin console:   http://localhost:8081  (KC_ADMIN_USERNAME/PASSWORD from .env)
+#
+# To use: set auth_backend: 'OIDC', fill in your real values below.
+# Note: OIDC redirect requires cookie_samesite: 'lax' (see below).
+# ──────────────────────────────────────────────────────────────
+# OIDC:
+#     # Issuer URL (the OpenID Connect discovery endpoint is <issuer>/.well-known/openid-configuration)
+#     # docker-compose service:          http://keycloak:8080/realms/keepass
+#     # running the app outside compose: http://localhost:8081/realms/keepass
+#     issuer: 'http://keycloak:8080/realms/keepass'
+#
+#     client_id: 'keepass4web'
+#     client_secret: 'insecure-example-client-secret'
+#
+#     # save the ID token in the session for cleaner single-logout
+#     # disable if the token is too large for the session cookie
+#     save_id_token: true
+#
+#     scopes:
+#       - 'profile'
+#       # add the 'keepass' scope if your IdP is configured to return
+#       # database_location / keyfile_location claims per user
+#       # - 'keepass'
+
+
+### General settings ###
+
+# Time before the database is automatically closed (user idle timeout).
+# User must re-enter the database master password after this.
+db_session_timeout: '10 minutes'
+
+# How often to re-check whether the auth backend has changed
+# (used to refresh the login page for idling users).
+auth_check_interval: '1 hour 5 minutes'
+
+search:
+  # Entry fields included in keyword search
+  fields:
+    - title
+    - username
+    - tags
+    - notes
+    - url
+  # also search custom fields and attachment file names
+  extra_fields: true
+  # allow regular expressions in search terms
+  allow_regex: false
+
+# Secret key for signing session cookies.
+# Must be at least 64 bytes, from a cryptographically secure source.
+# Generated on the fly when omitted — sessions do not survive restarts.
+# Set a static value to keep sessions across restarts.
+# session_secret_key: ''
+
+# How long a session cookie lives in the browser.
+session_lifetime: '1 hour'
+
+# SameSite policy for the session cookie: strict / lax / none
+# Use 'lax' when auth_backend is OIDC (redirect flow requires it).
+cookie_samesite: 'strict'
+# cookie_samesite: 'lax'   # ← uncomment when using OIDC
+
+# Trust Forwarded / X-Forwarded-For headers for the client IP.
+# Used by login rate limiting.  Only enable when running behind a
+# reverse proxy you control; these headers are client-spoofable otherwise.
+trust_proxy_headers: false
+
+# Use the Linux kernel keyring for session key storage (Linux only).
+# Set to false if your container runtime blocks keyctl/add_key/request_key
+# (e.g. Docker Desktop on macOS without a custom seccomp profile).
+# Ignored on non-Linux platforms, which always use the in-memory store.
+use_keyring: true
+
+listen: '::'
+port:   8080

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,9 @@ LDAP:
     uri:    'ldap://127.0.0.1:389'
     scope:  'subtree'
     base_dn: 'OU=People,DC=example,DC=org'
+    # additional filter, automatically combined with the login attribute match:
+    # (&(<login_attribute>=<username>)<filter>)
+    # no placeholder substitution takes place, leave empty to match on the login attribute only
     filter: '(&(objectClass=inetOrgPerson)(memberOf=CN=keepass,OU=groups,DC=example,DC=org))'
 
     # (unique) ldap attribute for user login

--- a/config.yml
+++ b/config.yml
@@ -105,5 +105,10 @@ session_lifetime: '1 hour'
 # Redirecting backends might require lax here
 cookie_samesite: 'strict'
 
+# Whether to trust Forwarded/X-Forwarded-For headers for the client ip
+# (used by login rate limiting). Only enable when running behind a
+# reverse proxy that sets these headers, they are spoofable otherwise.
+trust_proxy_headers: false
+
 listen:  '::'
 port:    8080

--- a/config.yml
+++ b/config.yml
@@ -110,5 +110,14 @@ cookie_samesite: 'strict'
 # reverse proxy that sets these headers, they are spoofable otherwise.
 trust_proxy_headers: false
 
+# Whether to use the Linux kernel keyring for session key storage.
+# Ignored on non-Linux platforms (always falls back to in-memory).
+# Set to false if your container runtime blocks the keyctl/add_key/request_key
+# syscalls — for example when running the Docker image on macOS with Docker
+# Desktop and no custom seccomp profile. The in-memory store is slightly
+# weaker (keys live in process memory rather than the kernel) but fully
+# functional for single-instance deployments.
+use_keyring: true
+
 listen:  '::'
 port:    8080

--- a/config.yml
+++ b/config.yml
@@ -1,123 +1,85 @@
 ##################################
 ### KeePass4Web related config ###
 ##################################
+#
+# This is the default configuration using local htpasswd authentication.
+# For LDAP or OIDC examples with pre-filled test values see config.example.yml.
+#
 
-# where to get keepass database from
-# available: Filesystem, HTTP
+# Where to get KeePass databases from.
+# Available: Filesystem, HTTP
 db_backend: 'Filesystem'
 
-# backend to authenticate users before anything else
-# available: None, LDAP, OIDC, htpasswd
-# None is only useful in single-user environments
-auth_backend: 'None'
+# Authentication backend.
+# Available: None, htpasswd, LDAP, OIDC
+# See config.example.yml for LDAP and OIDC configuration examples.
+auth_backend: 'htpasswd'
+
 
 ### Database backends ###
 
-# filesystem specific configuration, db_backend = 'Filesystem'
+# db_backend: Filesystem
 Filesystem:
     db_location: './db.kdbx'
-    # optional, storing key files on the filesystem is not recommended
+    # optional key file — storing key files on the server is not recommended
     # keyfile_location: './db.key'
 
-# http specific configuration, db_backend = 'HTTP'
-HTTP:
-    # database_url: ''
-    # keyfile_url: ''
-    # credentials:
-    #   username: ''
-    #   password: ''
-    # bearer: ''
+# db_backend: HTTP
+# HTTP:
+#     database_url: ''
+#     # keyfile_url: ''
+#     # credentials:
+#     #   username: ''
+#     #   password: ''
+#     # bearer: ''
+
 
 ### Authentication backends ###
 
-# ldap specific configuration, auth_backend = 'LDAP'
-LDAP:
-    uri:    'ldap://127.0.0.1:389'
-    scope:  'subtree'
-    base_dn: 'OU=People,DC=example,DC=org'
-    # additional filter, automatically combined with the login attribute match:
-    # (&(<login_attribute>=<username>)<filter>)
-    # no placeholder substitution takes place, leave empty to match on the login attribute only
-    filter: '(&(objectClass=inetOrgPerson)(memberOf=CN=keepass,OU=groups,DC=example,DC=org))'
-
-    # (unique) ldap attribute for user login
-    # Active Directory: sAMAccountName or userPrincipalName
-    # openLDAP/389 Directory Server/etc: uid
-    login_attribute: 'uid'
-
-    # ldap bind DN and password, leave empty for anonymous bind
-    bind:     'CN=ldap-read,OU=Special Users,DC=example,DC=org'
-    password: ''
-
-    # ldap attribute containing the keepass database and/or keyfile location for the authed user
-    # leave commented out to use static db/keyfile location from db backend
-    # database_attribute: 'keePass'
-    # keyfile_attribute:  'keePassKeyFile'
-
-# open id connect specific configuration, auth_backend = 'OIDC'
-OIDC:
-    # url to the issuer (discovery url)
-    # issuer: ''
-    client_id: ''
-    client_secret: ''
-    # required for logout without confirmation
-    # the token is pretty big and might not fit into a session cookie
-    # disable if issues arise
-    save_id_token: true
-    scopes:
-      - 'profile'
-      # scope containing the keepass_location and/or keyfile_location claims for the authed user
-      # leave commented out to use static db/keyfile location from db backend
-      # - 'keepass'
-
-# htpasswd specific configuration, auth_backend = 'htpasswd'
+# auth_backend: htpasswd
+# Create the password file with: htpasswd -cB .htpasswd <username>
 htpasswd:
     path: '.htpasswd'
 
-# time till database gets closed (user idle time)
-# user will have to reenter database password/keyfile
+
+### General settings ###
+
+# Time before the database is automatically closed (user idle timeout).
 db_session_timeout: '10 minutes'
-# interval to watch for user auth_backend changes (to present proper login page, even when user is idling)
+
+# How often to re-check whether the auth backend has changed.
 auth_check_interval: '1 hour 5 minutes'
 
 search:
-  # fields to search for matching entries
   fields:
     - title
     - username
     - tags
     - notes
     - url
-  # whether to search in user supplied fields and file names
   extra_fields: true
-  # whether regexes in the search pattern are interpreted
   allow_regex: false
 
-
-# Secret key used for session cookies
-# Must be at least 64 bytes long, obtained from a cryptographically secure source.
-# Will be generated on the fly if not specified.
-# Set a static key for sessions to survive server restarts.
+# Secret key for signing session cookies (at least 64 bytes).
+# Generated on the fly when omitted — sessions don't survive restarts.
+# Set a static value to keep sessions across restarts.
 # session_secret_key: ''
-# Cookie session lifetime
+
+# How long a session cookie lives in the browser.
 session_lifetime: '1 hour'
-# Cookie same site setting: strict/lax/none
-# Redirecting backends might require lax here
+
+# SameSite policy for the session cookie: strict / lax / none
+# Use 'lax' when auth_backend is OIDC (redirect flow requires it).
 cookie_samesite: 'strict'
 
-# Whether to trust Forwarded/X-Forwarded-For headers for the client ip
-# (used by login rate limiting). Only enable when running behind a
-# reverse proxy that sets these headers, they are spoofable otherwise.
+# Trust Forwarded / X-Forwarded-For headers for the client IP.
+# Only enable when running behind a reverse proxy you control.
 trust_proxy_headers: false
 
-# Whether to use the Linux kernel keyring for session key storage.
-# Ignored on non-Linux platforms (always falls back to in-memory).
-# Set to false if your container runtime blocks the keyctl/add_key/request_key
-# syscalls — for example when running the Docker image on macOS with Docker
-# Desktop and no custom seccomp profile. The in-memory store is slightly
-# weaker (keys live in process memory rather than the kernel) but fully
-# functional for single-instance deployments.
+# Use the Linux kernel keyring for session key storage (Linux only).
+# Set to false if your container runtime blocks keyctl/add_key/request_key
+# (e.g. Docker Desktop on macOS without a custom seccomp profile).
 use_keyring: true
 
-listen:  '::'
-port:    8080
+listen: '::'
+port:   8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,63 @@ services:
       - ./tests/test.kdbx:/db.kdbx
     security_opt:
       - seccomp=seccomp/keyring.json
+
+  ### Optional auth backends for testing ###
+  #
+  # The services below are disabled by default. To enable one, remove the
+  # leading '#' from its block (and from the matching volumes entry at the
+  # bottom, where present), then run: docker compose up -d
+  #
+  # --- OpenLDAP (auth_backend: LDAP) ---
+  #
+  # Seeded with user 'testuser' / password 'testpass'.
+  # Matching config.yml settings:
+  #
+  #   auth_backend: 'LDAP'
+  #   LDAP:
+  #     uri: 'ldap://openldap:1389'        # 'ldap://127.0.0.1:1389' when running the app outside compose
+  #     scope: 'subtree'
+  #     base_dn: 'ou=users,dc=example,dc=org'
+  #     filter: '(objectClass=inetOrgPerson)'
+  #     login_attribute: 'uid'
+  #     bind: 'cn=admin,dc=example,dc=org'
+  #     password: 'adminpassword'
+  #
+  #openldap:
+  #  image: docker.io/bitnamilegacy/openldap:2.6
+  #  ports:
+  #    - "1389:1389"
+  #  environment:
+  #    - LDAP_ROOT=dc=example,dc=org
+  #    - LDAP_ADMIN_USERNAME=admin
+  #    - LDAP_ADMIN_PASSWORD=adminpassword
+  #    - LDAP_USERS=testuser
+  #    - LDAP_PASSWORDS=testpass
+
+  # --- Keycloak (auth_backend: OIDC) ---
+  #
+  # Admin console: http://localhost:8081 (admin / admin).
+  # One-time setup: create a realm (e.g. 'keepass'), add a client with
+  # 'Client authentication' enabled, set its valid redirect URI to
+  # http://localhost:8080/callback_user_auth, create a test user with a
+  # password, then copy the client id/secret into config.yml:
+  #
+  #   auth_backend: 'OIDC'
+  #   OIDC:
+  #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
+  #     client_id: 'keepass4web'
+  #     client_secret: '<client secret from Keycloak>'
+  #     save_id_token: true
+  #     scopes:
+  #       - 'profile'
+  #
+  # Note: redirecting auth backends may require cookie_samesite: 'lax'.
+  #
+  #keycloak:
+  #  image: quay.io/keycloak/keycloak:26.0
+  #  command: start-dev
+  #  ports:
+  #    - "8081:8080"
+  #  environment:
+  #    - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,12 @@ services:
   # The realm 'keepass' is imported automatically from tests/keycloak/realm.json:
   # confidential client 'keepass4web' (secret in .env.example) with the redirect
   # URI http://localhost:8080/callback_user_auth, and user 'testuser' / 'testpass'.
-  # Admin console: http://localhost:8081 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
+  # Admin console: http://localhost:8180 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
   # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'OIDC'
   #   OIDC:
-  #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
+  #     issuer: 'http://keycloak:8180/realms/keepass'   # 'http://localhost:8180/realms/keepass' outside compose
   #     client_id: 'keepass4web'
   #     client_secret: 'insecure-example-client-secret'
   #     save_id_token: true
@@ -65,9 +65,9 @@ services:
   #
   #keycloak:
   #  image: quay.io/keycloak/keycloak:26.0
-  #  command: start-dev --import-realm
+  #  command: start-dev --http-port=8180 --import-realm
   #  ports:
-  #    - "8081:8080"
+  #    - "8180:8180"
   #  volumes:
   #    - ./tests/keycloak:/opt/keycloak/data/import:ro
   #  environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,16 @@ services:
 
   ### Optional auth backends for testing ###
   #
-  # The services below are disabled by default. To enable one, remove the
-  # leading '#' from its block (and from the matching volumes entry at the
-  # bottom, where present), then run: docker compose up -d
+  # The services below are disabled by default. To enable one:
+  #   1. cp .env.example .env   (example credentials, adjust if you like)
+  #   2. remove the leading '#' from the service block you need
+  #      (openldap for auth_backend: LDAP, keycloak for auth_backend: OIDC)
+  #   3. update config.yml as shown below, then: docker compose up -d
   #
   # --- OpenLDAP (auth_backend: LDAP) ---
   #
-  # Seeded with user 'testuser' / password 'testpass'.
-  # Matching config.yml settings:
+  # Seeded with the LDAP_TEST_USER / LDAP_TEST_PASSWORD user from .env.
+  # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'LDAP'
   #   LDAP:
@@ -36,25 +38,25 @@ services:
   #  ports:
   #    - "1389:1389"
   #  environment:
-  #    - LDAP_ROOT=dc=example,dc=org
-  #    - LDAP_ADMIN_USERNAME=admin
-  #    - LDAP_ADMIN_PASSWORD=adminpassword
-  #    - LDAP_USERS=testuser
-  #    - LDAP_PASSWORDS=testpass
+  #    - LDAP_ROOT=${LDAP_ROOT}
+  #    - LDAP_ADMIN_USERNAME=${LDAP_ADMIN_USERNAME}
+  #    - LDAP_ADMIN_PASSWORD=${LDAP_ADMIN_PASSWORD}
+  #    - LDAP_USERS=${LDAP_TEST_USER}
+  #    - LDAP_PASSWORDS=${LDAP_TEST_PASSWORD}
 
   # --- Keycloak (auth_backend: OIDC) ---
   #
-  # Admin console: http://localhost:8081 (admin / admin).
-  # One-time setup: create a realm (e.g. 'keepass'), add a client with
-  # 'Client authentication' enabled, set its valid redirect URI to
-  # http://localhost:8080/callback_user_auth, create a test user with a
-  # password, then copy the client id/secret into config.yml:
+  # The realm 'keepass' is imported automatically from tests/keycloak/realm.json:
+  # confidential client 'keepass4web' (secret in .env.example) with the redirect
+  # URI http://localhost:8080/callback_user_auth, and user 'testuser' / 'testpass'.
+  # Admin console: http://localhost:8081 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
+  # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'OIDC'
   #   OIDC:
   #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
   #     client_id: 'keepass4web'
-  #     client_secret: '<client secret from Keycloak>'
+  #     client_secret: 'insecure-example-client-secret'
   #     save_id_token: true
   #     scopes:
   #       - 'profile'
@@ -63,9 +65,11 @@ services:
   #
   #keycloak:
   #  image: quay.io/keycloak/keycloak:26.0
-  #  command: start-dev
+  #  command: start-dev --import-realm
   #  ports:
   #    - "8081:8080"
+  #  volumes:
+  #    - ./tests/keycloak:/opt/keycloak/data/import:ro
   #  environment:
-  #    - KC_BOOTSTRAP_ADMIN_USERNAME=admin
-  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+  #    - KC_BOOTSTRAP_ADMIN_USERNAME=${KC_ADMIN_USERNAME}
+  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=${KC_ADMIN_PASSWORD}

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -12,21 +12,31 @@ function generatePassword(length = 20) {
     return Array.from(arr).map(b => charset[b % charset.length]).join('')
 }
 
+const EMPTY_FORM = { title: '', username: '', password: '', url: '', notes: '' }
+
 class GroupViewer extends React.Component {
     constructor(props) {
         super(props)
         this.state = {
+            // new entry form
             showForm: false,
-            form: { title: '', username: '', password: '', url: '', notes: '' },
+            form: { ...EMPTY_FORM },
             saving: false,
             showPassword: false,
+            // edit entry
+            editEntry: null,
+            editForm: { ...EMPTY_FORM },
+            editSaving: false,
+            editShowPassword: false,
+            // rename group
+            editingTitle: false,
+            titleDraft: '',
+            titleSaving: false,
+            // new group
+            showGroupForm: false,
+            newGroupName: '',
+            groupSaving: false,
         }
-        this.onNewEntry = this.onNewEntry.bind(this)
-        this.onFormChange = this.onFormChange.bind(this)
-        this.onSubmit = this.onSubmit.bind(this)
-        this.onCancel = this.onCancel.bind(this)
-        this.onGeneratePassword = this.onGeneratePassword.bind(this)
-        this.toggleShowPassword = this.toggleShowPassword.bind(this)
     }
 
     getIcon(element) {
@@ -36,8 +46,10 @@ class GroupViewer extends React.Component {
             return <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(element.icon) + '.png'}/>
     }
 
+    // ── new entry ────────────────────────────────────────────────────────────
+
     onNewEntry() {
-        this.setState({ showForm: true, showPassword: false, form: { title: '', username: '', password: '', url: '', notes: '' } })
+        this.setState({ showForm: true, showPassword: false, form: { ...EMPTY_FORM }, editEntry: null })
     }
 
     onCancel() {
@@ -49,25 +61,16 @@ class GroupViewer extends React.Component {
     }
 
     onGeneratePassword() {
-        const pw = generatePassword()
-        this.setState(prev => ({ form: { ...prev.form, password: pw }, showPassword: true }))
-    }
-
-    toggleShowPassword() {
-        this.setState(prev => ({ showPassword: !prev.showPassword }))
+        this.setState(prev => ({ form: { ...prev.form, password: generatePassword() }, showPassword: true }))
     }
 
     onSubmit(e) {
         e.preventDefault()
         if (!this.props.group) return
         this.setState({ saving: true })
-
         KeePass4Web.fetch('entry', {
             method: 'POST',
-            data: {
-                group_id: this.props.group.id,
-                ...this.state.form,
-            },
+            data: { group_id: this.props.group.id, ...this.state.form },
             success: (data) => {
                 this.setState({ showForm: false, saving: false })
                 if (this.props.onEntryCreated) this.props.onEntryCreated(data && data.id)
@@ -79,119 +82,311 @@ class GroupViewer extends React.Component {
         })
     }
 
-    render() {
-        const classes = Classnames({
-            'panel': true,
-            'panel-default': true,
-            'loading-mask': this.props.mask,
+    // ── edit entry ───────────────────────────────────────────────────────────
+
+    onEditEntry(entry, ev) {
+        ev.stopPropagation()
+        this.setState({
+            editEntry: entry,
+            editForm: { title: entry.title || '', username: entry.username || '', password: '', url: entry.url || '', notes: '' },
+            editShowPassword: false,
+            showForm: false,
         })
+    }
+
+    onEditFormChange(field, e) {
+        this.setState(prev => ({ editForm: { ...prev.editForm, [field]: e.target.value } }))
+    }
+
+    onEditGeneratePassword() {
+        this.setState(prev => ({ editForm: { ...prev.editForm, password: generatePassword() }, editShowPassword: true }))
+    }
+
+    onEditSubmit(e) {
+        e.preventDefault()
+        const { editEntry, editForm } = this.state
+        this.setState({ editSaving: true })
+        KeePass4Web.fetch('entry', {
+            method: 'PUT',
+            data: { id: editEntry.id, ...editForm },
+            success: () => {
+                this.setState({ editEntry: null, editSaving: false })
+                if (this.props.onEntryCreated) this.props.onEntryCreated()
+            },
+            error: (err) => {
+                this.setState({ editSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── create group ─────────────────────────────────────────────────────────
+
+    onNewGroup() {
+        this.setState({ showGroupForm: true, newGroupName: '', showForm: false, editEntry: null })
+    }
+
+    onGroupFormSubmit(e) {
+        e.preventDefault()
+        if (!this.props.group || !this.state.newGroupName.trim()) return
+        this.setState({ groupSaving: true })
+        KeePass4Web.fetch('group', {
+            method: 'POST',
+            data: { parent_id: this.props.group.id, title: this.state.newGroupName.trim() },
+            success: () => {
+                this.setState({ showGroupForm: false, newGroupName: '', groupSaving: false })
+                if (this.props.onGroupCreated) this.props.onGroupCreated()
+            },
+            error: (err) => {
+                this.setState({ groupSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── rename group ─────────────────────────────────────────────────────────
+
+    onRenameStart() {
+        this.setState({ editingTitle: true, titleDraft: this.props.group.title })
+    }
+
+    onRenameSave(e) {
+        e.preventDefault()
+        const { titleDraft } = this.state
+        if (!titleDraft.trim()) return
+        this.setState({ titleSaving: true })
+        KeePass4Web.fetch('group', {
+            method: 'PUT',
+            data: { id: this.props.group.id, title: titleDraft.trim() },
+            success: () => {
+                this.setState({ editingTitle: false, titleSaving: false })
+                if (this.props.onGroupRenamed) this.props.onGroupRenamed(this.props.group.id, titleDraft.trim())
+            },
+            error: (err) => {
+                this.setState({ titleSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── render helpers ───────────────────────────────────────────────────────
+
+    renderPasswordInput(value, showField, onChangeFn, onToggleFn, onGenFn) {
+        const eyeIcon = showField ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
+        return (
+            <div className="input-group">
+                <input
+                    className="form-control"
+                    type={showField ? 'text' : 'password'}
+                    placeholder="Password (leave blank to keep existing)"
+                    value={value}
+                    onChange={onChangeFn}
+                />
+                <div className="input-group-btn">
+                    <button type="button" className="btn btn-default btn-sm" title="Show / hide" onClick={onToggleFn}>
+                        <span className={'glyphicon ' + eyeIcon}></span>
+                    </button>
+                    <button type="button" className="btn btn-default btn-sm" title="Generate random password" onClick={onGenFn}>
+                        <span className="glyphicon glyphicon-refresh"></span>
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    renderEntryForm(form, showPw, onChangeFn, onTogglePw, onGenPw, onSubmitFn, onCancelFn, saving) {
+        return (
+            <tr key="entry-form">
+                <td colSpan="3">
+                    <form onSubmit={onSubmitFn}>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Title" required autoFocus
+                                value={form.title} onChange={onChangeFn.bind(this, 'title')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Username"
+                                value={form.username} onChange={onChangeFn.bind(this, 'username')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            {this.renderPasswordInput(
+                                form.password, showPw,
+                                onChangeFn.bind(this, 'password'),
+                                onTogglePw, onGenPw
+                            )}
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="URL"
+                                value={form.url} onChange={onChangeFn.bind(this, 'url')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Notes"
+                                value={form.notes} onChange={onChangeFn.bind(this, 'notes')} />
+                        </div>
+                        <div className="btn-group">
+                            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
+                                {saving ? 'Saving…' : 'Save'}
+                            </button>
+                            <button type="button" className="btn btn-default btn-sm" onClick={onCancelFn}>
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
+                </td>
+            </tr>
+        )
+    }
+
+    render() {
+        const classes = Classnames({ 'panel': true, 'panel-default': true, 'loading-mask': this.props.mask })
 
         if (!this.props.group) return (<div className={classes}></div>)
 
         const group = this.props.group
         const isSearchResult = group.id === NIL_UUID
+        const canAddGroup = !isSearchResult && (this.props.groupDepth === undefined || this.props.groupDepth < 2)
+        const { editEntry, editingTitle, titleDraft, titleSaving, showGroupForm, newGroupName, groupSaving } = this.state
 
+        // ── group heading ────────────────────────────────────────────────────
+        let heading
+        if (editingTitle) {
+            heading = (
+                <form className="form-inline" onSubmit={this.onRenameSave.bind(this)}
+                      style={{ display: 'inline' }}>
+                    <div className="input-group input-group-sm" style={{ maxWidth: 260 }}>
+                        <input
+                            className="form-control"
+                            value={titleDraft}
+                            autoFocus
+                            onChange={e => this.setState({ titleDraft: e.target.value })}
+                        />
+                        <div className="input-group-btn">
+                            <button type="submit" className="btn btn-primary btn-sm" disabled={titleSaving}>
+                                {titleSaving ? '…' : <span className="glyphicon glyphicon-ok"></span>}
+                            </button>
+                            <button type="button" className="btn btn-default btn-sm"
+                                onClick={() => this.setState({ editingTitle: false })}>
+                                <span className="glyphicon glyphicon-remove"></span>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            )
+        } else {
+            heading = (
+                <span>
+                    {this.getIcon(group)}
+                    {group.title}
+                    {!isSearchResult && (
+                        <button className="btn btn-link btn-xs" style={{ padding: '0 4px' }}
+                            title="Rename group" onClick={this.onRenameStart.bind(this)}>
+                            <span className="glyphicon glyphicon-pencil"></span>
+                        </button>
+                    )}
+                </span>
+            )
+        }
+
+        // ── entry rows ───────────────────────────────────────────────────────
         let entries = []
         for (var i in group.entries) {
             let entry = group.entries[i]
+            const isEditing = editEntry && editEntry.id === entry.id
 
             entries.push(
-                <tr key={i} onClick={this.props.onSelect.bind(this, entry)}>
+                <tr key={entry.id} onClick={this.props.onSelect.bind(this, entry)}
+                    className={isEditing ? 'active' : ''}>
                     <td className="kp-wrap">
                         {this.getIcon(entry)}
                         {entry.title}
                     </td>
-                    <td className="kp-wrap">
-                        {entry.username}
-                    </td>
-                    <td>
-                        <button
-                            className="btn btn-danger btn-xs"
-                            title="Delete entry"
-                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}
-                        >
+                    <td className="kp-wrap">{entry.username}</td>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                        <button className="btn btn-default btn-xs" title="Edit entry"
+                            onClick={this.onEditEntry.bind(this, entry)}>
+                            <span className="glyphicon glyphicon-pencil"></span>
+                        </button>
+                        {' '}
+                        <button className="btn btn-danger btn-xs" title="Delete entry"
+                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}>
                             <span className="glyphicon glyphicon-trash"></span>
                         </button>
                     </td>
                 </tr>
             )
+
+            if (isEditing) {
+                entries.push(this.renderEntryForm(
+                    this.state.editForm,
+                    this.state.editShowPassword,
+                    this.onEditFormChange.bind(this),
+                    () => this.setState(p => ({ editShowPassword: !p.editShowPassword })),
+                    this.onEditGeneratePassword.bind(this),
+                    this.onEditSubmit.bind(this),
+                    () => this.setState({ editEntry: null }),
+                    this.state.editSaving,
+                ))
+            }
         }
 
+        // ── new entry form ───────────────────────────────────────────────────
         let newEntryForm = null
         if (this.state.showForm) {
-            const eyeIcon = this.state.showPassword ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
-            newEntryForm = (
-                <tr key="new-entry-form">
-                    <td colSpan="3">
-                        <form onSubmit={this.onSubmit}>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Title" required autoFocus
-                                    value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Username"
-                                    value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <div className="input-group">
-                                    <input
-                                        className="form-control"
-                                        type={this.state.showPassword ? 'text' : 'password'}
-                                        placeholder="Password"
-                                        value={this.state.form.password}
-                                        onChange={this.onFormChange.bind(this, 'password')}
-                                    />
-                                    <div className="input-group-btn">
-                                        <button type="button" className="btn btn-default btn-sm"
-                                            title="Show / hide password"
-                                            onClick={this.toggleShowPassword}>
-                                            <span className={'glyphicon ' + eyeIcon}></span>
-                                        </button>
-                                        <button type="button" className="btn btn-default btn-sm"
-                                            title="Generate random password"
-                                            onClick={this.onGeneratePassword}>
-                                            <span className="glyphicon glyphicon-refresh"></span>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="URL"
-                                    value={this.state.form.url} onChange={this.onFormChange.bind(this, 'url')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Notes"
-                                    value={this.state.form.notes} onChange={this.onFormChange.bind(this, 'notes')} />
-                            </div>
-                            <div className="btn-group">
-                                <button type="submit" className="btn btn-primary btn-sm" disabled={this.state.saving}>
-                                    {this.state.saving ? 'Saving…' : 'Save'}
-                                </button>
-                                <button type="button" className="btn btn-default btn-sm" onClick={this.onCancel}>
-                                    Cancel
-                                </button>
-                            </div>
-                        </form>
-                    </td>
-                </tr>
+            newEntryForm = this.renderEntryForm(
+                this.state.form,
+                this.state.showPassword,
+                this.onFormChange.bind(this),
+                () => this.setState(p => ({ showPassword: !p.showPassword })),
+                this.onGeneratePassword.bind(this),
+                this.onSubmit.bind(this),
+                this.onCancel.bind(this),
+                this.state.saving,
             )
         }
 
         return (
             <div className={classes}>
-                <div className="panel-heading">
-                    {this.getIcon(group)}
-                    {group.title}
-                    {!isSearchResult && (
-                        <button
-                            className="btn btn-success btn-xs pull-right"
-                            onClick={this.onNewEntry}
-                            title="New entry"
-                        >
-                            <span className="glyphicon glyphicon-plus"></span> New Entry
-                        </button>
+                <div className="panel-heading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span>{heading}</span>
+                    {!isSearchResult && !editingTitle && (
+                        <span>
+                            {canAddGroup && (
+                                <button className="btn btn-info btn-xs" style={{ marginRight: 4 }}
+                                    onClick={this.onNewGroup.bind(this)} title="Add subgroup">
+                                    <span className="glyphicon glyphicon-folder-open"></span> Add Group
+                                </button>
+                            )}
+                            <button className="btn btn-success btn-xs"
+                                onClick={this.onNewEntry.bind(this)} title="New entry">
+                                <span className="glyphicon glyphicon-plus"></span> New Entry
+                            </button>
+                        </span>
                     )}
                 </div>
+                {showGroupForm && (
+                    <div className="panel-body" style={{ paddingTop: 8, paddingBottom: 8, borderBottom: '1px solid #ddd' }}>
+                        <form className="form-inline" onSubmit={this.onGroupFormSubmit.bind(this)}>
+                            <div className="input-group input-group-sm" style={{ maxWidth: 300 }}>
+                                <input
+                                    className="form-control"
+                                    placeholder="Group name"
+                                    required
+                                    autoFocus
+                                    value={newGroupName}
+                                    onChange={e => this.setState({ newGroupName: e.target.value })}
+                                />
+                                <div className="input-group-btn">
+                                    <button type="submit" className="btn btn-primary btn-sm" disabled={groupSaving}>
+                                        {groupSaving ? '…' : 'Create'}
+                                    </button>
+                                    <button type="button" className="btn btn-default btn-sm"
+                                        onClick={() => this.setState({ showGroupForm: false })}>
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                )}
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">
                         <thead>

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -7,6 +7,15 @@ import withNavigateHook from './nagivateHook'
 class GroupViewer extends React.Component {
     constructor(props) {
         super(props)
+        this.state = {
+            showForm: false,
+            form: { title: '', username: '', password: '', url: '', notes: '' },
+            saving: false,
+        }
+        this.onNewEntry = this.onNewEntry.bind(this)
+        this.onFormChange = this.onFormChange.bind(this)
+        this.onSubmit = this.onSubmit.bind(this)
+        this.onCancel = this.onCancel.bind(this)
     }
 
     getIcon(element) {
@@ -14,6 +23,40 @@ class GroupViewer extends React.Component {
             return <img className="kp-icon" src={'api/v1/icon/' + encodeURIComponent(element.custom_icon_uuid)}/>
         else if (element.icon)
             return <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(element.icon) + '.png'}/>
+    }
+
+    onNewEntry() {
+        this.setState({ showForm: true, form: { title: '', username: '', password: '', url: '', notes: '' } })
+    }
+
+    onCancel() {
+        this.setState({ showForm: false })
+    }
+
+    onFormChange(field, e) {
+        this.setState(prev => ({ form: { ...prev.form, [field]: e.target.value } }))
+    }
+
+    onSubmit(e) {
+        e.preventDefault()
+        if (!this.props.group) return
+        this.setState({ saving: true })
+
+        KeePass4Web.fetch('entry', {
+            method: 'POST',
+            data: {
+                group_id: this.props.group.id,
+                ...this.state.form,
+            },
+            success: (data) => {
+                this.setState({ showForm: false, saving: false })
+                if (this.props.onEntryCreated) this.props.onEntryCreated(data && data.id)
+            },
+            error: (err) => {
+                this.setState({ saving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
     }
 
     render() {
@@ -40,6 +83,55 @@ class GroupViewer extends React.Component {
                     <td className="kp-wrap">
                         {entry.username}
                     </td>
+                    <td>
+                        <button
+                            className="btn btn-danger btn-xs"
+                            title="Delete entry"
+                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}
+                        >
+                            <span className="glyphicon glyphicon-trash"></span>
+                        </button>
+                    </td>
+                </tr>
+            )
+        }
+
+        let newEntryForm = null
+        if (this.state.showForm) {
+            newEntryForm = (
+                <tr key="new-entry-form">
+                    <td colSpan="3">
+                        <form onSubmit={this.onSubmit}>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Title" required
+                                    value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Username"
+                                    value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" type="password" placeholder="Password"
+                                    value={this.state.form.password} onChange={this.onFormChange.bind(this, 'password')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="URL"
+                                    value={this.state.form.url} onChange={this.onFormChange.bind(this, 'url')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Notes"
+                                    value={this.state.form.notes} onChange={this.onFormChange.bind(this, 'notes')} />
+                            </div>
+                            <div className="btn-group">
+                                <button type="submit" className="btn btn-primary btn-sm" disabled={this.state.saving}>
+                                    {this.state.saving ? 'Saving…' : 'Save'}
+                                </button>
+                                <button type="button" className="btn btn-default btn-sm" onClick={this.onCancel}>
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </td>
                 </tr>
             )
         }
@@ -49,21 +141,26 @@ class GroupViewer extends React.Component {
                 <div className="panel-heading">
                     {this.getIcon(group)}
                     {group.title}
+                    <button
+                        className="btn btn-success btn-xs pull-right"
+                        onClick={this.onNewEntry}
+                        title="New entry"
+                    >
+                        <span className="glyphicon glyphicon-plus"></span> New Entry
+                    </button>
                 </div>
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">
                         <thead>
                         <tr>
-                            <th>
-                                Entry Name
-                            </th>
-                            <th>
-                                Username
-                            </th>
+                            <th>Entry Name</th>
+                            <th>Username</th>
+                            <th></th>
                         </tr>
                         </thead>
                         <tbody className="groupview-body">
                         {entries}
+                        {newEntryForm}
                         </tbody>
                     </table>
                 </div>

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -3,6 +3,14 @@ import Classnames from 'classnames'
 
 import withNavigateHook from './nagivateHook'
 
+const NIL_UUID = '00000000-0000-0000-0000-000000000000'
+
+function generatePassword(length = 20) {
+    const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?'
+    const arr = new Uint8Array(length)
+    window.crypto.getRandomValues(arr)
+    return Array.from(arr).map(b => charset[b % charset.length]).join('')
+}
 
 class GroupViewer extends React.Component {
     constructor(props) {
@@ -11,11 +19,14 @@ class GroupViewer extends React.Component {
             showForm: false,
             form: { title: '', username: '', password: '', url: '', notes: '' },
             saving: false,
+            showPassword: false,
         }
         this.onNewEntry = this.onNewEntry.bind(this)
         this.onFormChange = this.onFormChange.bind(this)
         this.onSubmit = this.onSubmit.bind(this)
         this.onCancel = this.onCancel.bind(this)
+        this.onGeneratePassword = this.onGeneratePassword.bind(this)
+        this.toggleShowPassword = this.toggleShowPassword.bind(this)
     }
 
     getIcon(element) {
@@ -26,7 +37,7 @@ class GroupViewer extends React.Component {
     }
 
     onNewEntry() {
-        this.setState({ showForm: true, form: { title: '', username: '', password: '', url: '', notes: '' } })
+        this.setState({ showForm: true, showPassword: false, form: { title: '', username: '', password: '', url: '', notes: '' } })
     }
 
     onCancel() {
@@ -35,6 +46,15 @@ class GroupViewer extends React.Component {
 
     onFormChange(field, e) {
         this.setState(prev => ({ form: { ...prev.form, [field]: e.target.value } }))
+    }
+
+    onGeneratePassword() {
+        const pw = generatePassword()
+        this.setState(prev => ({ form: { ...prev.form, password: pw }, showPassword: true }))
+    }
+
+    toggleShowPassword() {
+        this.setState(prev => ({ showPassword: !prev.showPassword }))
     }
 
     onSubmit(e) {
@@ -69,6 +89,7 @@ class GroupViewer extends React.Component {
         if (!this.props.group) return (<div className={classes}></div>)
 
         const group = this.props.group
+        const isSearchResult = group.id === NIL_UUID
 
         let entries = []
         for (var i in group.entries) {
@@ -98,12 +119,13 @@ class GroupViewer extends React.Component {
 
         let newEntryForm = null
         if (this.state.showForm) {
+            const eyeIcon = this.state.showPassword ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
             newEntryForm = (
                 <tr key="new-entry-form">
                     <td colSpan="3">
                         <form onSubmit={this.onSubmit}>
                             <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Title" required
+                                <input className="form-control" placeholder="Title" required autoFocus
                                     value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
                             </div>
                             <div className="form-group form-group-sm">
@@ -111,8 +133,27 @@ class GroupViewer extends React.Component {
                                     value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
                             </div>
                             <div className="form-group form-group-sm">
-                                <input className="form-control" type="password" placeholder="Password"
-                                    value={this.state.form.password} onChange={this.onFormChange.bind(this, 'password')} />
+                                <div className="input-group">
+                                    <input
+                                        className="form-control"
+                                        type={this.state.showPassword ? 'text' : 'password'}
+                                        placeholder="Password"
+                                        value={this.state.form.password}
+                                        onChange={this.onFormChange.bind(this, 'password')}
+                                    />
+                                    <div className="input-group-btn">
+                                        <button type="button" className="btn btn-default btn-sm"
+                                            title="Show / hide password"
+                                            onClick={this.toggleShowPassword}>
+                                            <span className={'glyphicon ' + eyeIcon}></span>
+                                        </button>
+                                        <button type="button" className="btn btn-default btn-sm"
+                                            title="Generate random password"
+                                            onClick={this.onGeneratePassword}>
+                                            <span className="glyphicon glyphicon-refresh"></span>
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
                             <div className="form-group form-group-sm">
                                 <input className="form-control" placeholder="URL"
@@ -141,13 +182,15 @@ class GroupViewer extends React.Component {
                 <div className="panel-heading">
                     {this.getIcon(group)}
                     {group.title}
-                    <button
-                        className="btn btn-success btn-xs pull-right"
-                        onClick={this.onNewEntry}
-                        title="New entry"
-                    >
-                        <span className="glyphicon glyphicon-plus"></span> New Entry
-                    </button>
+                    {!isSearchResult && (
+                        <button
+                            className="btn btn-success btn-xs pull-right"
+                            onClick={this.onNewEntry}
+                            title="New entry"
+                        >
+                            <span className="glyphicon glyphicon-plus"></span> New Entry
+                        </button>
+                    )}
                 </div>
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">

--- a/js/scripts/NavBar.js
+++ b/js/scripts/NavBar.js
@@ -118,6 +118,17 @@ class NavBar extends React.Component {
             }
         }
 
+        const saveBtn = this.props.onSaveDb ? (
+            <ul className="nav navbar-nav navbar-right">
+                <li>
+                    <a href="" onClick={(e) => { e.preventDefault(); this.props.onSaveDb() }}
+                       title="Save database to disk">
+                        <span className="glyphicon glyphicon-floppy-disk"></span> Save
+                    </a>
+                </li>
+            </ul>
+        ) : null
+
         return (
             <nav className="navbar navbar-default navbar-fixed-top">
                 <div className="navbar-header">
@@ -133,6 +144,7 @@ class NavBar extends React.Component {
                 </div>
                 <div className="collapse navbar-collapse" id="navbar-collapse-1">
                     {search}
+                    {saveBtn}
                     <ul className="nav navbar-nav navbar-right">
                         <li className="dropdown">
                             <a href="" className="dropdown-toggle" data-toggle="dropdown" role="button"

--- a/js/scripts/Viewport.js
+++ b/js/scripts/Viewport.js
@@ -15,15 +15,27 @@ class Viewport extends React.Component {
         this.onEntryCreated = this.onEntryCreated.bind(this)
         this.onDeleteEntry = this.onDeleteEntry.bind(this)
         this.onSaveDb = this.onSaveDb.bind(this)
+        this.onGroupRenamed = this.onGroupRenamed.bind(this)
+        this.onGroupCreated = this.onGroupCreated.bind(this)
 
         this.state = {
             tree: {},
             entry: null,
             group: null,
+            groupDepth: 0,
             saveModal: false,
             savePassword: '',
             saveStatus: '',
         }
+    }
+
+    findGroupDepth(group, targetId, depth = 0) {
+        if (group.id === targetId) return depth
+        for (const child of (group.children || [])) {
+            const d = this.findGroupDepth(child, targetId, depth + 1)
+            if (d >= 0) return d
+        }
+        return -1
     }
 
     scroll(id) {
@@ -39,7 +51,8 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({ entry: null, groupMask: true })
+        const depth = this.findGroupDepth(this.state.tree, group.id)
+        this.setState({ entry: null, groupMask: true, groupDepth: depth >= 0 ? depth : 0 })
 
         this.serverRequest = KeePass4Web.fetch('get_group_entries', {
             method: 'GET',
@@ -107,6 +120,29 @@ class Viewport extends React.Component {
 
     onEntryCreated() {
         this.refreshGroup()
+    }
+
+    onGroupCreated() {
+        KeePass4Web.fetch('get_groups', {
+            method: 'GET',
+            success: (data) => this.setState({ tree: data.groups }),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onGroupRenamed(groupId, newTitle) {
+        // Patch the title in the tree without a full reload
+        const patchTree = (groups) => groups.map(g => ({
+            ...g,
+            title: g.id === groupId ? newTitle : g.title,
+            children: g.children ? patchTree(g.children) : g.children,
+        }))
+        this.setState(prev => ({
+            tree: { ...prev.tree, children: patchTree(prev.tree.children || []) },
+            group: prev.group && prev.group.id === groupId
+                ? { ...prev.group, title: newTitle }
+                : prev.group,
+        }))
     }
 
     onDeleteEntry(entry) {
@@ -207,10 +243,13 @@ class Viewport extends React.Component {
                     <div id="group-viewer" className="col-sm-4">
                         <GroupViewer
                             group={this.state.group}
+                            groupDepth={this.state.groupDepth}
                             onSelect={this.onSelect}
                             mask={this.state.groupMask}
                             onEntryCreated={this.onEntryCreated}
                             onDeleteEntry={this.onDeleteEntry}
+                            onGroupRenamed={this.onGroupRenamed}
+                            onGroupCreated={this.onGroupCreated}
                         />
                     </div>
                     <div id="node-viewer" className="col-sm-6">

--- a/js/scripts/Viewport.js
+++ b/js/scripts/Viewport.js
@@ -12,18 +12,23 @@ class Viewport extends React.Component {
         this.onGroupSelect = this.onGroupSelect.bind(this)
         this.onSelect = this.onSelect.bind(this)
         this.onSearch = this.onSearch.bind(this)
+        this.onEntryCreated = this.onEntryCreated.bind(this)
+        this.onDeleteEntry = this.onDeleteEntry.bind(this)
+        this.onSaveDb = this.onSaveDb.bind(this)
 
         this.state = {
             tree: {},
             entry: null,
             group: null,
+            saveModal: false,
+            savePassword: '',
+            saveStatus: '',
         }
     }
 
     scroll(id) {
         document.getElementById(id).scrollIntoView()
         if (window.scrollY)
-            // scroll height of bootstrap fixed header down
             window.scroll(0, scrollY - 70)
     }
 
@@ -34,66 +39,38 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            entry: null,
-            groupMask: true,
-        })
+        this.setState({ entry: null, groupMask: true })
 
         this.serverRequest = KeePass4Web.fetch('get_group_entries', {
-            method: "GET",
-            data: {
-                id: group.id,
-            },
-            success: function (data) {
-                this.setState({
-                    group: data,
-                })
-
+            method: 'GET',
+            data: { id: group.id },
+            success: (data) => {
+                this.setState({ group: data })
                 this.scroll('group-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    groupMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ groupMask: false }),
         })
     }
 
     onSelect(entry) {
         if (!entry || !entry.id) return
-        // ignore already selected
         if (this.state.entry && this.state.entry.id && entry.id === this.state.entry.id) return
 
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            nodeMask: true,
-        })
+        this.setState({ nodeMask: true })
         this.serverRequest = KeePass4Web.fetch('get_entry', {
-            method: "GET",
-            data: {
-                id: entry.id,
-            },
-            success: function (data) {
-                // remove entry first to rerender entry
-                // important for eye close/open buttons
-                this.setState({
-                    entry: null,
-                })
-                this.setState({
-                    entry: data,
-                })
-
+            method: 'GET',
+            data: { id: entry.id },
+            success: (data) => {
+                this.setState({ entry: null })
+                this.setState({ entry: data })
                 this.scroll('node-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    nodeMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ nodeMask: false }),
         })
     }
 
@@ -103,46 +80,67 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            entry: null,
-            groupMask: true,
-        })
+        this.setState({ entry: null, groupMask: true })
 
         this.serverRequest = KeePass4Web.fetch('search_entries', {
-            method: "GET",
-            data: {
-                term: refs.term.value.replace(/^\s+|\s+$/g, ''),
-            },
-            success: function (data) {
-                this.setState({
-                    group: data,
-                    groupMask: false,
-                })
-
+            method: 'GET',
+            data: { term: refs.term.value.replace(/^\s+|\s+$/g, '') },
+            success: (data) => {
+                this.setState({ group: data, groupMask: false })
                 this.scroll('group-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    groupMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ groupMask: false }),
+        })
+    }
+
+    // Re-fetch the current group after a write so the entry list updates
+    refreshGroup() {
+        if (!this.state.group || !this.state.group.id) return
+        KeePass4Web.fetch('get_group_entries', {
+            method: 'GET',
+            data: { id: this.state.group.id },
+            success: (data) => this.setState({ group: data, entry: null }),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onEntryCreated() {
+        this.refreshGroup()
+    }
+
+    onDeleteEntry(entry) {
+        if (!window.confirm(`Delete "${entry.title}"?`)) return
+
+        KeePass4Web.fetch('entry', {
+            method: 'DELETE',
+            data: { id: entry.id },
+            success: () => this.refreshGroup(),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onSaveDb(e) {
+        e.preventDefault()
+        this.setState({ saveStatus: 'Saving…' })
+        KeePass4Web.fetch('save_db', {
+            method: 'POST',
+            data: { password: this.state.savePassword },
+            success: () => this.setState({ saveModal: false, savePassword: '', saveStatus: '' }),
+            error: (err) => {
+                this.setState({ saveStatus: err.message || 'Save failed' })
+            },
         })
     }
 
     componentDidMount() {
-        // TODO: add loading mask for the whole viewport while fetching groups
         KeePass4Web.fetch('get_groups', {
-            method: "GET",
-            success: function (data) {
-                this.setState({
-                    tree: data.groups
-                })
+            method: 'GET',
+            success: (data) => {
+                this.setState({ tree: data.groups })
                 if (data.last_selected)
-                    this.onGroupSelect({
-                        id: data.last_selected
-                    })
-            }.bind(this),
+                    this.onGroupSelect({ id: data.last_selected })
+            },
             error: KeePass4Web.error.bind(this),
         })
     }
@@ -153,12 +151,51 @@ class Viewport extends React.Component {
     }
 
     render() {
+        const saveModal = this.state.saveModal ? (
+            <div style={{
+                position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+                background: 'rgba(0,0,0,.5)', zIndex: 1050, display: 'flex',
+                alignItems: 'center', justifyContent: 'center',
+            }}>
+                <div className="panel panel-default" style={{ width: 340, padding: 16 }}>
+                    <div className="panel-heading"><b>Save Database to Disk</b></div>
+                    <div className="panel-body">
+                        <p>Re-enter your master password to write changes to the server file.</p>
+                        <form onSubmit={this.onSaveDb}>
+                            <div className="form-group">
+                                <input
+                                    type="password"
+                                    className="form-control"
+                                    placeholder="Master password"
+                                    autoFocus
+                                    value={this.state.savePassword}
+                                    onChange={e => this.setState({ savePassword: e.target.value, saveStatus: '' })}
+                                />
+                            </div>
+                            {this.state.saveStatus && (
+                                <p className="text-danger">{this.state.saveStatus}</p>
+                            )}
+                            <div className="btn-group">
+                                <button type="submit" className="btn btn-primary">Save</button>
+                                <button type="button" className="btn btn-default"
+                                    onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}>
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        ) : null
+
         return (
             <div className="container-fluid">
                 <NavBar
                     showSearch
                     onSearch={this.onSearch}
+                    onSaveDb={() => this.setState({ saveModal: true })}
                 />
+                {saveModal}
                 <div className="row">
                     <div className="col-sm-2 dir-tree">
                         <TreeViewer
@@ -172,6 +209,8 @@ class Viewport extends React.Component {
                             group={this.state.group}
                             onSelect={this.onSelect}
                             mask={this.state.groupMask}
+                            onEntryCreated={this.onEntryCreated}
+                            onDeleteEntry={this.onDeleteEntry}
                         />
                     </div>
                     <div id="node-viewer" className="col-sm-6">

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -180,7 +180,7 @@ async fn get_login_type(request: &HttpRequest) -> Result<LoginType> {
     };
     let session = request.get_session();
     let host = format!("{}://{}", request.connection_info().scheme(), request.connection_info().host());
-    let login_type = auth_backend::new(config).get_login_type(&host, cache)?;
+    let login_type = auth_backend::new(config).get_login_type(&host, cache).await?;
 
     match &login_type {
         Redirect { state, .. } => {

--- a/src/auth_backend.rs
+++ b/src/auth_backend.rs
@@ -66,7 +66,9 @@ pub trait AuthBackend: Send + Sync {
 
     fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
 
-    //  TODO: handle case sensitivity
+    // backends returning case-insensitive user names must lowercase
+    // UserInfo.id: it keys the db cache (see ldap/htpasswd). OIDC subjects
+    // are case-sensitive opaque strings and are used as-is.
     async fn login(&self, _username: &str, _password: &str) -> Result<UserInfo> {
         bail!("login method not supported")
     }

--- a/src/auth_backend.rs
+++ b/src/auth_backend.rs
@@ -62,9 +62,9 @@ pub trait AuthBackend: Send + Sync {
 
     async fn init(&self) -> Result<AuthCache> { Ok(Box::new(())) }
 
-    fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType>;
+    async fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType>;
 
-    fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
+    async fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
 
     // backends returning case-insensitive user names must lowercase
     // UserInfo.id: it keys the db cache (see ldap/htpasswd). OIDC subjects

--- a/src/auth_backend/htpasswd.rs
+++ b/src/auth_backend/htpasswd.rs
@@ -39,7 +39,7 @@ impl AuthBackend for Htpasswd {
         self.config.validate()
     }
 
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/auth_backend/htpasswd.rs
+++ b/src/auth_backend/htpasswd.rs
@@ -48,7 +48,8 @@ impl AuthBackend for Htpasswd {
 
         Ok(
             UserInfo {
-                id: username.to_owned(),
+                // lowercase like the ldap backend, the id keys the db cache
+                id: username.to_lowercase(),
                 name: username.to_owned(),
                 db_location: None,
                 keyfile_location: None,

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -48,7 +48,7 @@ impl AuthBackend for Ldap {
         self.config.validate()
     }
 
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -18,6 +18,20 @@ impl Ldap {
             config: config.ldap.clone()
         }
     }
+
+    // resulting filter: (&(<login_attribute>=<username>)<configured filter>),
+    // or just (<login_attribute>=<username>) if no filter is configured
+    fn search_filter(&self, username: &str) -> String {
+        let user_match = format!(
+            "({}={})",
+            self.config.login_attribute,
+            ldap_escape(username),
+        );
+        match self.config.filter.trim() {
+            "" | "()" => user_match,
+            filter => format!("(&{}{})", user_match, filter),
+        }
+    }
 }
 
 #[async_trait]
@@ -27,13 +41,19 @@ impl AuthBackend for Ldap {
     }
 
     async fn login(&self, username: &str, password: &str) -> Result<UserInfo> {
+        // an empty password would result in an anonymous bind, which most ldap
+        // servers report as success, bypassing the password check entirely
+        if password.is_empty() {
+            bail!("empty password");
+        }
+
         let (conn, mut ldap) = LdapConnAsync::new(self.config.uri.as_str()).await?;
 
         drive!(conn);
         ldap.simple_bind(
             self.config.bind.as_str(),
             self.config.password.as_str(),
-        ).await?;
+        ).await?.success()?;
 
         let mut attrs = vec![CN_ATTR];
         if let Some(k) = &self.config.database_attribute {
@@ -44,25 +64,22 @@ impl AuthBackend for Ldap {
         }
 
         // find user dn
+        let filter = self.search_filter(username);
         let (results, _res) = ldap.search(
             self.config.base_dn.as_str(),
             self.config.scope.clone().into(),
-            format!(
-                "(&({}={}){})",
-                ldap_escape(&self.config.login_attribute),
-                ldap_escape(username),
-                self.config.filter
-            ).as_str(),
+            filter.as_str(),
             attrs,
         ).await?.success()?;
-        ldap.unbind().await?;
 
         if results.is_empty() {
-            bail!("no users found");
+            bail!("no users found with filter '{}'", filter);
         }
 
         let user = SearchEntry::construct(results[0].clone());
 
+        // verify credentials by rebinding as the found user,
+        // before unbind: unbind terminates the connection
         ldap.simple_bind(
             user.dn.as_str(),
             password,
@@ -96,5 +113,42 @@ impl AuthBackend for Ldap {
                 additional_data: None,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend(filter: &str) -> Ldap {
+        Ldap {
+            config: ldap::Ldap {
+                filter: filter.to_string(),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn filter_is_combined_with_login_attribute() {
+        assert_eq!(
+            backend("(objectClass=inetOrgPerson)").search_filter("alice"),
+            "(&(uid=alice)(objectClass=inetOrgPerson))",
+        );
+    }
+
+    #[test]
+    fn empty_filter_matches_login_attribute_only() {
+        assert_eq!(backend("").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("  ").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("()").search_filter("alice"), "(uid=alice)");
+    }
+
+    #[test]
+    fn username_is_escaped() {
+        assert_eq!(
+            backend("").search_filter("a*)(uid=*"),
+            "(uid=a\\2a\\29\\28uid=\\2a)",
+        );
     }
 }

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -44,6 +44,10 @@ impl Ldap {
 
 #[async_trait]
 impl AuthBackend for Ldap {
+    fn validate_config(&self) -> Result<()> {
+        self.config.validate()
+    }
+
     fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -8,6 +8,14 @@ use crate::config::ldap;
 
 const CN_ATTR: &str = "CN";
 
+// ldap attribute names are case-insensitive (RFC 4512), but servers return
+// them in their own canonical casing, e.g. openldap returns 'cn' for 'CN'
+fn get_attr_ci<'a>(attrs: &'a std::collections::HashMap<String, Vec<String>>, name: &str) -> Option<&'a Vec<String>> {
+    attrs.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v)
+}
+
 pub struct Ldap {
     pub(crate) config: ldap::Ldap,
 }
@@ -55,7 +63,7 @@ impl AuthBackend for Ldap {
             self.config.password.as_str(),
         ).await?.success()?;
 
-        let mut attrs = vec![CN_ATTR];
+        let mut attrs = vec![CN_ATTR, self.config.login_attribute.as_str()];
         if let Some(k) = &self.config.database_attribute {
             attrs.push(k);
         }
@@ -86,20 +94,20 @@ impl AuthBackend for Ldap {
         ).await?.success()?;
         ldap.unbind().await?;
 
-        let cn = user.attrs.get(CN_ATTR)
+        let cn = get_attr_ci(&user.attrs, CN_ATTR)
             .ok_or(anyhow!("CN attribute not found"))?;
-        let id = user.attrs.get(&self.config.login_attribute)
+        let id = get_attr_ci(&user.attrs, &self.config.login_attribute)
             .ok_or(anyhow!("login attribute '{}' not found", &self.config.login_attribute))?;
 
         let mut db_location = None;
         let mut keyfile_location = None;
         if let Some(key) = &self.config.database_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 db_location = Some(v[0].clone());
             }
         }
         if let Some(key) = &self.config.keyfile_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 keyfile_location = Some(v[0].clone());
             }
         }
@@ -142,6 +150,17 @@ mod tests {
         assert_eq!(backend("").search_filter("alice"), "(uid=alice)");
         assert_eq!(backend("  ").search_filter("alice"), "(uid=alice)");
         assert_eq!(backend("()").search_filter("alice"), "(uid=alice)");
+    }
+
+    #[test]
+    fn attribute_lookup_is_case_insensitive() {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("cn".to_string(), vec!["Test User".to_string()]);
+        attrs.insert("uID".to_string(), vec!["testuser".to_string()]);
+
+        assert_eq!(get_attr_ci(&attrs, "CN").unwrap()[0], "Test User");
+        assert_eq!(get_attr_ci(&attrs, "uid").unwrap()[0], "testuser");
+        assert!(get_attr_ci(&attrs, "mail").is_none());
     }
 
     #[test]

--- a/src/auth_backend/none.rs
+++ b/src/auth_backend/none.rs
@@ -7,7 +7,7 @@ pub struct None;
 
 #[async_trait]
 impl AuthBackend for None {
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::None)
     }
 

--- a/src/auth_backend/oidc.rs
+++ b/src/auth_backend/oidc.rs
@@ -1,7 +1,10 @@
 use std::str::FromStr;
 use std::string::ToString;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Result};
+use log::warn;
+use tokio::sync::RwLock;
 use async_trait::async_trait;
 use constant_time_eq::constant_time_eq;
 use openidconnect::{
@@ -108,6 +111,29 @@ pub struct Oidc {
     pub(crate) config: oidc::Oidc,
 }
 
+// how long provider metadata (incl. the JWKS) is served from cache
+// before it is re-fetched on the next use
+const METADATA_TTL: Duration = Duration::from_secs(10 * 60);
+
+// lazily populated, periodically refreshed provider metadata.
+// fetching at every use would hammer the provider, caching forever breaks
+// logins when the provider rotates its signing keys or was down at startup.
+#[derive(Default)]
+pub struct MetadataCache {
+    lock: RwLock<Option<CachedMetadata>>,
+}
+
+struct CachedMetadata {
+    metadata: ProviderMetadataWithLogout,
+    fetched: Instant,
+}
+
+impl CachedMetadata {
+    fn is_fresh(&self) -> bool {
+        self.fetched.elapsed() < METADATA_TTL
+    }
+}
+
 impl Oidc {
     pub fn new(config: &Config) -> Self {
         Self {
@@ -115,9 +141,7 @@ impl Oidc {
         }
     }
 
-    fn get_client(&self, host: &str, cache: &AuthCache) -> Result<OidcClient> {
-        let provider_metadata = Self::get_metadata(cache)?;
-
+    fn get_client(&self, host: &str, provider_metadata: ProviderMetadataWithLogout) -> Result<OidcClient> {
         let client: OidcClient = Client::new(
             ClientId::new(self.config.client_id.clone()),
             Some(ClientSecret::new(self.config.client_secret.clone())),
@@ -134,10 +158,50 @@ impl Oidc {
         Ok(client)
     }
 
-    fn get_metadata(cache: &AuthCache) -> Result<&ProviderMetadataWithLogout> {
-        match cache.downcast_ref::<ProviderMetadataWithLogout>() {
-            Some(v) => Ok(v),
-            None => bail!("failed to retrieve provider metadata from cache"),
+    async fn get_metadata(&self, cache: &AuthCache, force_refresh: bool) -> Result<ProviderMetadataWithLogout> {
+        let cache = match cache.downcast_ref::<MetadataCache>() {
+            Some(v) => v,
+            None => bail!("failed to retrieve provider metadata cache"),
+        };
+
+        if !force_refresh {
+            if let Some(cached) = cache.lock.read().await.as_ref() {
+                if cached.is_fresh() {
+                    return Ok(cached.metadata.clone());
+                }
+            }
+        }
+
+        let mut guard = cache.lock.write().await;
+        // another task may have refreshed while we waited for the write lock
+        if !force_refresh {
+            if let Some(cached) = guard.as_ref() {
+                if cached.is_fresh() {
+                    return Ok(cached.metadata.clone());
+                }
+            }
+        }
+
+        match ProviderMetadataWithLogout::discover_async(
+            // issuer presence is enforced by validate_config at startup
+            IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
+            async_http_client,
+        ).await {
+            Ok(metadata) => {
+                *guard = Some(CachedMetadata {
+                    metadata: metadata.clone(),
+                    fetched: Instant::now(),
+                });
+                Ok(metadata)
+            }
+            Err(err) => {
+                // keep serving the stale copy if the provider is temporarily unreachable
+                if let Some(cached) = guard.as_ref() {
+                    warn!("OIDC provider metadata refresh failed, serving cached copy: {}", err);
+                    return Ok(cached.metadata.clone());
+                }
+                Err(err.into())
+            }
         }
     }
 }
@@ -149,18 +213,20 @@ impl AuthBackend for Oidc {
     }
 
     async fn init(&self) -> Result<AuthCache> {
-        Ok(
-            Box::new(
-                ProviderMetadataWithLogout::discover_async(
-                    IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
-                    async_http_client,
-                ).await?
-            )
-        )
+        let cache: AuthCache = Box::new(MetadataCache::default());
+
+        // best-effort warm-up: an unreachable provider must not prevent
+        // startup, metadata is (re)fetched lazily when a login needs it
+        if let Err(err) = self.get_metadata(&cache, false).await {
+            warn!("OIDC provider discovery failed at startup (will retry on demand): {}", err);
+        }
+
+        Ok(cache)
     }
 
-    fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType> {
-        let client = self.get_client(host, cache)?;
+    async fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType> {
+        let metadata = self.get_metadata(cache, false).await?;
+        let client = self.get_client(host, metadata)?;
 
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
@@ -190,14 +256,14 @@ impl AuthBackend for Oidc {
         )
     }
 
-    fn get_logout_type(&self, user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> {
-        let provider_metadata = Self::get_metadata(_cache)?;
+    async fn get_logout_type(&self, user_info: &UserInfo, host: &str, cache: &AuthCache) -> Result<LogoutType> {
+        let provider_metadata = self.get_metadata(cache, false).await?;
         let logout_endpoint = provider_metadata.additional_metadata().end_session_endpoint.
             clone().ok_or(anyhow!("no session endpoint defined"))?;
 
         let mut logout_request = LogoutRequest::from(logout_endpoint)
             .set_post_logout_redirect_uri(
-                PostLogoutRedirectUrl::new(_host.to_string())?
+                PostLogoutRedirectUrl::new(host.to_string())?
             )
             .set_client_id(ClientId::new(self.config.client_id.clone()));
 
@@ -229,7 +295,8 @@ impl AuthBackend for Oidc {
             bail!("invalid csrf token (state)");
         }
 
-        let client = self.get_client(host, cache)?;
+        let metadata = self.get_metadata(cache, false).await?;
+        let client = self.get_client(host, metadata)?;
         let token_response = client
             .exchange_code(AuthorizationCode::new(oidc_params.code))
             .set_pkce_verifier(PkceCodeVerifier::new(state.pkce))
@@ -240,7 +307,20 @@ impl AuthBackend for Oidc {
             .id_token()
             .ok_or(anyhow!("server did not return an ID token"))?;
 
-        let claims = id_token.claims(&client.id_token_verifier(), &Nonce::new(state.nonce))?;
+        let nonce = Nonce::new(state.nonce);
+        // declared here so the retry's claims may borrow from it below
+        let refreshed_client;
+        let claims = match id_token.claims(&client.id_token_verifier(), &nonce) {
+            Ok(claims) => claims,
+            Err(err) => {
+                // the provider may have rotated its signing keys since the
+                // metadata was cached: refresh once and retry
+                warn!("ID token verification failed, refreshing provider metadata: {}", err);
+                let metadata = self.get_metadata(cache, true).await?;
+                refreshed_client = self.get_client(host, metadata)?;
+                id_token.claims(&refreshed_client.id_token_verifier(), &nonce)?
+            }
+        };
 
         if let Some(expected_access_token_hash) = claims.access_token_hash() {
             let actual_access_token_hash = AccessTokenHash::from_token(
@@ -274,5 +354,59 @@ impl AuthBackend for Oidc {
                 additional_data,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use url::Url;
+
+    use super::*;
+
+    fn backend(issuer: &str) -> Oidc {
+        let mut config = Config::default();
+        config.oidc.issuer = Some(Url::from_str(issuer).unwrap());
+        config.oidc.client_id = "test-client".to_string();
+        config.oidc.client_secret = "test-secret".to_string();
+        Oidc::new(&config)
+    }
+
+    #[tokio::test]
+    async fn discovery_is_lazy_and_recovers() {
+        let mut server = mockito::Server::new_async().await;
+        let issuer = format!("{}/", server.url());
+        let oidc = backend(&issuer);
+
+        // provider is 'down' (no mocks registered): init must still succeed,
+        // login attempts surface the error per request
+        let cache = oidc.init().await.unwrap();
+        assert!(oidc.get_login_type("http://localhost:8080", &cache).await.is_err());
+
+        // provider comes up: the next login attempt must succeed
+        // without any re-initialization
+        let discovery = json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{}auth", issuer),
+            "token_endpoint": format!("{}token", issuer),
+            "jwks_uri": format!("{}jwks", issuer),
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        });
+        server.mock("GET", "/.well-known/openid-configuration")
+            .with_header("content-type", "application/json")
+            .with_body(discovery.to_string())
+            .create_async().await;
+        server.mock("GET", "/jwks")
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"keys":[]}"#)
+            .create_async().await;
+
+        let login_type = oidc.get_login_type("http://localhost:8080", &cache).await.unwrap();
+        match login_type {
+            LoginType::Redirect { url, .. } => assert!(url.as_str().starts_with(&format!("{}auth", issuer))),
+            _ => panic!("expected redirect login type"),
+        }
     }
 }

--- a/src/auth_backend/oidc.rs
+++ b/src/auth_backend/oidc.rs
@@ -40,6 +40,7 @@ use openidconnect::core::{
     CoreGenderClaim,
     CoreIdToken,
     CoreJsonWebKey,
+    CoreJsonWebKeySet,
     CoreJsonWebKeyType,
     CoreJsonWebKeyUse,
     CoreJweContentEncryptionAlgorithm,
@@ -50,6 +51,7 @@ use openidconnect::core::{
     CoreTokenType,
 };
 use openidconnect::reqwest::async_http_client;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::auth_backend::{AuthBackend, AuthCache, LoginType, LogoutType, ROUTE_CALLBACK_USER_AUTH, UserInfo};
@@ -109,6 +111,7 @@ struct OidcParams {
 
 pub struct Oidc {
     pub(crate) config: oidc::Oidc,
+    http_client: HttpClient,
 }
 
 // how long provider metadata (incl. the JWKS) is served from cache
@@ -138,6 +141,7 @@ impl Oidc {
     pub fn new(config: &Config) -> Self {
         Self {
             config: config.oidc.clone(),
+            http_client: HttpClient::new(),
         }
     }
 
@@ -156,6 +160,70 @@ impl Oidc {
             )?
         );
         Ok(client)
+    }
+
+    async fn fetch_metadata_from_url(&self, url: &str) -> Result<ProviderMetadataWithLogout> {
+        let body = self.http_client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        let body = self.rewrite_server_endpoints(body, url)?;
+        let metadata: ProviderMetadataWithLogout = serde_json::from_str(&body)?;
+
+        // openidconnect marks the JWKS field #[serde(skip)], so raw deserialization
+        // leaves it empty. Fetch the JWKS separately from the (already-rewritten) URI.
+        let jwks_body = self.http_client
+            .get(metadata.jwks_uri().url().as_str())
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        let jwks: CoreJsonWebKeySet = serde_json::from_str(&jwks_body)?;
+        Ok(metadata.set_jwks(jwks))
+    }
+
+    // In container setups where discovery_url differs from issuer (e.g. internal
+    // http://keycloak:8180 vs external http://localhost:8180), Keycloak's --hostname
+    // flag causes it to return all endpoint URLs with the external hostname even when
+    // the discovery doc is fetched from the internal URL. Rewrite the server-to-server
+    // endpoints (token, jwks, userinfo) to use the internal host so the app can reach
+    // them, while leaving browser-facing URLs (authorization_endpoint,
+    // end_session_endpoint) pointing at the external host so redirects still work.
+    fn rewrite_server_endpoints(&self, body: String, discovery_url: &str) -> Result<String> {
+        let issuer = match &self.config.issuer {
+            Some(u) => u,
+            None => return Ok(body),
+        };
+
+        let discovery_origin = url_origin(discovery_url);
+        let issuer_origin = url_origin(issuer.as_str());
+
+        if discovery_origin == issuer_origin || discovery_origin.is_empty() || issuer_origin.is_empty() {
+            return Ok(body);
+        }
+
+        let mut json: serde_json::Value = serde_json::from_str(&body)?;
+        for field in &[
+            "token_endpoint",
+            "jwks_uri",
+            "userinfo_endpoint",
+            "introspection_endpoint",
+            "revocation_endpoint",
+            "device_authorization_endpoint",
+        ] {
+            if let Some(val) = json.get_mut(*field) {
+                if let Some(url_str) = val.as_str() {
+                    *val = serde_json::Value::String(
+                        url_str.replacen(&issuer_origin, &discovery_origin, 1),
+                    );
+                }
+            }
+        }
+        Ok(serde_json::to_string(&json)?)
     }
 
     async fn get_metadata(&self, cache: &AuthCache, force_refresh: bool) -> Result<ProviderMetadataWithLogout> {
@@ -182,11 +250,19 @@ impl Oidc {
             }
         }
 
-        match ProviderMetadataWithLogout::discover_async(
-            // issuer presence is enforced by validate_config at startup
-            IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
-            async_http_client,
-        ).await {
+        let result = match &self.config.discovery_url {
+            // discovery_url bypasses the openidconnect issuer-must-match check so the
+            // app can fetch metadata from an internal URL (e.g. http://keycloak:8180)
+            // while the issuer in tokens is an external URL (e.g. http://localhost:8180).
+            Some(url) => self.fetch_metadata_from_url(url.as_str()).await.map_err(Into::into),
+            None => ProviderMetadataWithLogout::discover_async(
+                // issuer presence is enforced by validate_config at startup
+                IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
+                async_http_client,
+            ).await.map_err(Into::into),
+        };
+
+        match result {
             Ok(metadata) => {
                 *guard = Some(CachedMetadata {
                     metadata: metadata.clone(),
@@ -200,7 +276,7 @@ impl Oidc {
                     warn!("OIDC provider metadata refresh failed, serving cached copy: {}", err);
                     return Ok(cached.metadata.clone());
                 }
-                Err(err.into())
+                Err(err)
             }
         }
     }
@@ -355,6 +431,20 @@ impl AuthBackend for Oidc {
             }
         )
     }
+}
+
+fn url_origin(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .map(|u| {
+            let mut s = format!("{}://{}", u.scheme(), u.host_str().unwrap_or(""));
+            if let Some(port) = u.port() {
+                s.push(':');
+                s.push_str(&port.to_string());
+            }
+            s
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/src/auth_backend/test.rs
+++ b/src/auth_backend/test.rs
@@ -7,7 +7,7 @@ pub struct Test;
 
 #[async_trait]
 impl AuthBackend for Test {
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -35,6 +35,9 @@ pub struct Config {
     pub session_lifetime: Duration,
     #[serde(with = "SameSiteDef")]
     pub cookie_samesite: cookie::SameSite,
+    // only enable behind a reverse proxy: forwarding headers are
+    // client-controlled and would let rate limiting be evaded
+    pub trust_proxy_headers: bool,
     pub search: Search,
     #[serde(alias = "LDAP", alias = "Ldap")]
     pub ldap: Ldap,
@@ -63,6 +66,7 @@ impl Default for Config {
             // 1 hour
             session_lifetime: Duration::from_secs(60 * 60),
             cookie_samesite: cookie::SameSite::Strict,
+            trust_proxy_headers: false,
             search: Default::default(),
             ldap: Default::default(),
             oidc: Default::default(),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -38,6 +38,11 @@ pub struct Config {
     // only enable behind a reverse proxy: forwarding headers are
     // client-controlled and would let rate limiting be evaded
     pub trust_proxy_headers: bool,
+    // use the linux kernel keyring for session key storage (linux only).
+    // set to false if your container runtime blocks keyctl/add_key/request_key
+    // (e.g. docker desktop on macos without a custom seccomp profile).
+    // ignored on non-linux platforms, which always use the in-memory store.
+    pub use_keyring: bool,
     pub search: Search,
     #[serde(alias = "LDAP", alias = "Ldap")]
     pub ldap: Ldap,
@@ -67,6 +72,7 @@ impl Default for Config {
             session_lifetime: Duration::from_secs(60 * 60),
             cookie_samesite: cookie::SameSite::Strict,
             trust_proxy_headers: false,
+            use_keyring: true,
             search: Default::default(),
             ldap: Default::default(),
             oidc: Default::default(),

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -1,4 +1,6 @@
+use anyhow::{bail, Result};
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Clone, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -33,6 +35,28 @@ pub struct Ldap {
     pub keyfile_attribute: Option<String>,
 }
 
+impl Ldap {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.uri.trim().is_empty() {
+            bail!("LDAP: uri must be specified");
+        }
+        match Url::parse(&self.uri) {
+            Ok(url) => match url.scheme() {
+                "ldap" | "ldaps" | "ldapi" => {}
+                scheme => bail!("LDAP: unsupported uri scheme '{}', expected ldap, ldaps or ldapi", scheme),
+            },
+            Err(err) => bail!("LDAP: invalid uri '{}': {}", self.uri, err),
+        }
+        if self.base_dn.trim().is_empty() {
+            bail!("LDAP: base_dn must be specified");
+        }
+        if self.login_attribute.trim().is_empty() {
+            bail!("LDAP: login_attribute must be specified");
+        }
+        Ok(())
+    }
+}
+
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
@@ -46,5 +70,49 @@ impl Default for Ldap {
             database_attribute: None,
             keyfile_attribute: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> Ldap {
+        Ldap {
+            base_dn: "ou=users,dc=example,dc=org".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        assert!(valid().validate().is_ok());
+
+        let mut ldaps = valid();
+        ldaps.uri = "ldaps://example.org:636".to_string();
+        assert!(ldaps.validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_config_fails() {
+        let mut c = valid();
+        c.uri = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "http://example.org".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "not a url".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.base_dn = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.login_attribute = " ".to_string();
+        assert!(c.validate().is_err());
     }
 }

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -36,10 +36,10 @@ pub struct Ldap {
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
-            uri: "ldap://localhost:339".to_string(),
+            uri: "ldap://localhost:389".to_string(),
             scope: Scope::default(),
             base_dn: "".to_string(),
-            filter: "()".to_string(),
+            filter: "".to_string(),
             login_attribute: "uid".to_string(),
             bind: "".to_string(),
             password: "".to_string(),

--- a/src/config/oidc.rs
+++ b/src/config/oidc.rs
@@ -7,6 +7,12 @@ use url::Url;
 #[serde(default)]
 pub struct Oidc {
     pub issuer: Option<Url>,
+    /// Override the URL used to fetch OIDC provider metadata.
+    /// Useful in Docker/container setups where the app reaches the provider
+    /// via an internal hostname (e.g. `http://keycloak:8180`) but the issuer
+    /// in tokens is an external hostname (e.g. `http://localhost:8180`).
+    /// When unset, metadata is fetched from `<issuer>/.well-known/openid-configuration`.
+    pub discovery_url: Option<Url>,
     pub client_id: String,
     pub client_secret: String,
     pub scopes: Vec<String>,
@@ -17,6 +23,7 @@ impl Default for Oidc {
     fn default() -> Self {
         Oidc {
             issuer: None,
+            discovery_url: None,
             client_id: "".to_string(),
             client_secret: "".to_string(),
             scopes: vec![],

--- a/src/db_backend/filesystem.rs
+++ b/src/db_backend/filesystem.rs
@@ -65,9 +65,10 @@ impl DbBackend for Filesystem {
             path = Path::new(db_location);
         }
 
+        // File::open opens read-only, writes would fail with EBADF
         Ok(
             (
-                Box::pin(File::open(
+                Box::pin(File::create(
                     path
                 ).await?),
                 None
@@ -89,5 +90,37 @@ impl Filesystem {
         Self {
             config: config.filesystem.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn write_roundtrip() {
+        let path = std::env::temp_dir().join("k4w-filesystem-write-test.kdbx");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        let mut config = Config::default();
+        config.filesystem.db_location = path.clone();
+        let mut backend = Filesystem::new(&config);
+
+        let data = b"some database content";
+        {
+            let (mut writer, rx) = backend.get_db_write(&UserInfo::default()).await.unwrap();
+            writer.write_all(data).await.unwrap();
+            writer.shutdown().await.unwrap();
+            assert!(rx.is_none());
+        }
+
+        let mut reader = backend.get_db_read(&UserInfo::default()).await.unwrap();
+        let mut read_back = vec![];
+        reader.read_to_end(&mut read_back).await.unwrap();
+        assert_eq!(read_back, data);
+
+        let _ = tokio::fs::remove_file(&path).await;
     }
 }

--- a/src/db_backend/http.rs
+++ b/src/db_backend/http.rs
@@ -21,6 +21,7 @@ use crate::db_backend::DbBackend;
 
 pub struct Http {
     pub config: http::Http,
+    client: Client,
 }
 
 #[async_trait]
@@ -105,7 +106,9 @@ impl DbBackend for Http {
 impl Http {
     pub fn new(config: &Config) -> Self {
         Self {
-            config: config.http.clone()
+            config: config.http.clone(),
+            // reuse one client for connection pooling and tls session reuse
+            client: Client::new(),
         }
     }
 
@@ -134,9 +137,7 @@ impl Http {
     }
 
     fn get_request(&self, method: Method, url: Url) -> Result<RequestBuilder> {
-        let mut req = Client::builder()
-            .build()?.
-            request(method, url);
+        let mut req = self.client.request(method, url);
 
         if let Some(cred) = &self.config.credentials {
             req = req.basic_auth(cred.username.clone(), cred.password.clone());

--- a/src/db_backend/http.rs
+++ b/src/db_backend/http.rs
@@ -32,7 +32,7 @@ impl DbBackend for Http {
     async fn get_db_read(&self, user_info: &UserInfo) -> Result<Pin<Box<dyn AsyncRead + '_>>> {
         let url = self.get_db_url(user_info)?;
 
-        let response = self.get_request(Method::GET, url)?.send().await?;
+        let response = self.get_request(Method::GET, url)?.send().await?.error_for_status()?;
         Ok(
             Self::get_boxed_response(response)
         )
@@ -62,7 +62,7 @@ impl DbBackend for Http {
             Err(err) => return Some(Err(err))
         };
 
-        match request.send().await {
+        match request.send().await.and_then(|r| r.error_for_status()) {
             Ok(response) => {
                 Some(Ok(Self::get_boxed_response(response)))
             }
@@ -81,7 +81,7 @@ impl DbBackend for Http {
 
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            tx.send(match req.send().await {
+            tx.send(match req.send().await.and_then(|r| r.error_for_status()) {
                 Ok(_) => Ok(()),
                 Err(err) => Err(err).map_err(Error::new),
             }) // ignore failed send
@@ -216,6 +216,38 @@ mod tests {
     #[tokio::test]
     async fn write_fail() {
         let res = write_http(Url::from_str("http://0.0.0.0").unwrap()).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/")
+            .with_body("<html>not found</html>")
+            .with_status(404)
+            .create_async().await;
+
+        let mut config = Config::default();
+        config.http.database_url = Some(Url::from_str(&server.url()).unwrap());
+        let http = Http::new(&config);
+        let res = http.get_db_read(&UserInfo::default()).await;
+
+        mock.assert_async().await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn write_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("PUT", "/")
+            .with_status(500)
+            .create_async().await;
+
+        let res = write_http(Url::from_str(&server.url()).unwrap()).await;
+
+        mock.assert_async().await;
 
         assert!(res.is_err());
     }

--- a/src/keepass/db_cache.rs
+++ b/src/keepass/db_cache.rs
@@ -43,15 +43,19 @@ impl Deref for DbCache {
 
 impl DbCache {
     pub async fn store(&self, session: &Session, enc_db: Encrypted) -> Result<()> {
-        self.write().await
-            .insert(
-                self.get_user(session)?, enc_db,
-            );
+        let user = self.get_user(session)?;
+        let mut cache = self.write().await;
+
+        // evict expired entries opportunistically, so the cache
+        // doesn't grow unboundedly with inactive users
+        let now = Instant::now();
+        cache.retain(|_, enc| now < enc.expiry);
+
+        cache.insert(user, enc_db);
 
         Ok(())
     }
 
-    // TODO: expire old entries periodically
     pub async fn retrieve(&self, session: &Session, timeout: Duration) -> Result<Encrypted> {
         let user = self.get_user(session)?;
         let mut enc = self.read().await.get(user.as_str()).ok_or(anyhow!("enc db not found in store"))?.clone();
@@ -82,5 +86,35 @@ impl DbCache {
         Ok(
             session.get::<UserInfo>(SESSION_KEY_USER)?.ok_or(anyhow!("unable to retrieve user from session"))?.id
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_session::SessionExt;
+    use actix_web::test::TestRequest;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn expired_entries_are_evicted_on_store() {
+        let cache = DbCache::default();
+        let req = TestRequest::default().to_http_request();
+        let session = req.get_session();
+        session.insert(SESSION_KEY_USER, UserInfo {
+            id: "alice".to_string(),
+            ..Default::default()
+        }).unwrap();
+
+        // expired entry of an inactive user
+        let (_, expired) = Encrypted::encrypt(vec![1, 2, 3], &[], Duration::from_secs(0)).unwrap();
+        cache.write().await.insert("bob".to_string(), expired);
+
+        let (_, fresh) = Encrypted::encrypt(vec![4, 5, 6], &[], Duration::from_secs(60)).unwrap();
+        cache.store(&session, fresh).await.unwrap();
+
+        let entries = cache.read().await;
+        assert!(entries.contains_key("alice"));
+        assert!(!entries.contains_key("bob"));
     }
 }

--- a/src/keepass/encrypted.rs
+++ b/src/keepass/encrypted.rs
@@ -9,8 +9,6 @@ use zeroize::Zeroize;
 
 use crate::keepass::key::SecretKey;
 
-const LENGTH_IV: usize = 16;
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Encrypted {
     data: Vec<u8>,
@@ -20,8 +18,7 @@ pub struct Encrypted {
 }
 
 impl Encrypted {
-    pub fn encrypt(mut input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
-        input.extend([0; LENGTH_IV]);
+    pub fn encrypt(input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
         let iv = Aes256Gcm::generate_nonce(&mut thread_rng()); // 96-bits; unique per message
         let mut enc = Encrypted {
             data: input,
@@ -42,7 +39,7 @@ impl Encrypted {
         let cipher = Aes256Gcm::new(key);
         cipher.decrypt_in_place(Nonce::from_slice(&self.iv), aad, &mut self.data)?;
 
-        let v = self.data[0..self.data.len() - LENGTH_IV].to_vec();
+        let v = self.data.clone();
         self.data.zeroize();
         Ok(SecretVec::new(v))
     }

--- a/src/keepass/entry.rs
+++ b/src/keepass/entry.rs
@@ -19,6 +19,7 @@ pub struct Group {
 
 #[derive(Serialize)]
 pub struct EntryGroup {
+    pub id: Uuid,
     pub title: String,
     pub icon: Option<usize>,
     pub custom_icon_uuid: Option<Uuid>,

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -230,12 +230,6 @@ impl KeePass {
         )
     }
 
-    pub fn get_file(&self, params: &Query<File>) -> Result<Vec<u8>> {
-        let _entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
-
-        todo!()
-    }
-
     pub fn search_entries(&self, params: &Query<SearchTerm>) -> Result<EntryGroup> {
         let mut term = params.term.clone();
         if !self.config.search.allow_regex {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -373,8 +373,9 @@ mod tests {
 
         let (mut key, enc) = keepass.to_enc().unwrap();
 
-        key.store(config.db_session_timeout).unwrap();
-        let ret_key = SecretKey::retrieve(&key.key_id, config.db_session_timeout).unwrap();
+        // tests always use the in-memory store; the keyring is unavailable in most CI/test environments
+        key.store(config.db_session_timeout, false).unwrap();
+        let ret_key = SecretKey::retrieve(&key.key_id, config.db_session_timeout, false).unwrap();
 
         let dec = KeePass::from_enc(&config, ret_key, enc).unwrap();
 

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -322,6 +322,7 @@ impl KeePass {
         }
 
         Ok(EntryGroup {
+            id: group.uuid,
             title: group.name.clone(),
             entries,
             icon: group.icon_id,
@@ -367,6 +368,7 @@ impl KeePass {
         let entries = Self::find_entries_by_string(&self.db.root, &rgx, &self.config.search);
 
         Ok(EntryGroup {
+            id: Uuid::nil(),
             title: format!("Search results for '{}'", params.term),
             entries,
             // search icon

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -26,6 +26,19 @@ use crate::keepass::entry::{
 };
 use crate::keepass::key::SecretKey;
 
+// distinguishes missing entries/groups/icons from real server faults,
+// so handlers can return 404 instead of 500
+#[derive(Debug, Clone)]
+pub struct NotFoundError(pub &'static str);
+
+impl std::fmt::Display for NotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} not found", self.0)
+    }
+}
+
+impl std::error::Error for NotFoundError {}
+
 #[derive(Deserialize)]
 pub struct Id {
     pub id: Uuid,
@@ -169,7 +182,7 @@ impl KeePass {
     }
 
     pub fn get_group_entries(&self, params: &Query<Id>) -> Result<EntryGroup> {
-        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(anyhow!("group not found"))?;
+        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(NotFoundError("group"))?;
 
         let mut entries = Vec::with_capacity(group.children.len());
         for node in &group.children {
@@ -202,13 +215,13 @@ impl KeePass {
     }
 
     pub fn get_entry(&self, params: &Query<Id>) -> Result<Entry> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(NotFoundError("entry"))?;
 
         Ok(entry.into())
     }
 
     pub fn get_protected(&self, params: &Query<Protected>) -> Result<SecretString> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(NotFoundError("entry"))?;
 
         let field = match params.name.as_str() {
             "password" => entry.fields.get("Password").cloned(),
@@ -220,7 +233,7 @@ impl KeePass {
                 Value::Protected(p) => p,
                 _ => bail!("not a protected field"),
             },
-            None => bail!("field not found"),
+            None => return Err(NotFoundError("field").into()),
         };
 
         Ok(
@@ -255,7 +268,7 @@ impl KeePass {
             }
         }
 
-        bail!("icon not found")
+        Err(NotFoundError("icon").into())
     }
 
     pub(crate) fn find_all_groups(group: &keepass::db::Group) -> Group {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -5,7 +5,8 @@ use base64;
 use base64::Engine;
 use base64::engine::general_purpose;
 use keepass::{Database, DatabaseKey};
-use keepass::db::{Icon, Node, Value};
+use keepass::config::DatabaseConfig;
+use keepass::db::{Entry as KpEntry, Group as KpGroup, Icon, Node, Value};
 use regex::Regex;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
@@ -90,27 +91,62 @@ impl KeePass {
         Encrypted::encrypt(ser_db, &[], self.config.db_session_timeout)
     }
 
-    pub async fn from_backend(config: &Config, db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<Self> {
+    pub async fn from_backend(config: &Config, db_backend: &mut dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<Self> {
         let db_key = Self::db_key_from_params(db_backend, params, user_info).await?;
 
-        let mut reader = db_backend.get_db_read(user_info).await?;
+        // Read the database into an owned buffer. The reader (which borrows db_backend)
+        // is dropped when the async block completes, releasing the immutable borrow before
+        // we potentially need &mut db_backend to create a new database.
+        let load_result: Result<Vec<u8>> = async {
+            let mut reader = db_backend.get_db_read(user_info).await?;
+            let mut buf = vec![];
+            reader.read_to_end(&mut buf).await?;
+            Ok(buf)
+        }.await;
 
-        // bridge sync and async by caching the whole file in memory for now
-        let mut buf = vec![];
-        reader.read_to_end(&mut buf).await?;
+        let buf = match load_result {
+            Ok(buf) => buf,
+            Err(err) => {
+                // No database at the configured path yet — create a new empty one.
+                if err.downcast_ref::<std::io::Error>()
+                    .map(|e| e.kind() == std::io::ErrorKind::NotFound)
+                    .unwrap_or(false)
+                {
+                    return Self::create_new(config, db_backend, db_key, user_info).await;
+                }
+                return Err(err);
+            }
+        };
 
         let db = tokio::task::spawn_blocking(move || {
+            let mut buf = buf;
             let db = Database::open(&mut buf.as_slice(), db_key);
             buf.zeroize();
             db
         }).await??;
 
-        Ok(
-            KeePass {
-                config: config.clone(),
-                db,
-            }
-        )
+        Ok(KeePass { config: config.clone(), db })
+    }
+
+    async fn create_new(config: &Config, db_backend: &mut dyn DbBackend, db_key: DatabaseKey, user_info: &UserInfo) -> Result<Self> {
+        let db = Database::new(DatabaseConfig::default());
+
+        let mut buf: Vec<u8> = vec![];
+        let (result, mut buf, db) = tokio::task::spawn_blocking(move || {
+            let r = db.save(&mut buf, db_key);
+            (r, buf, db)
+        }).await?;
+        result.map_err(|e| anyhow::anyhow!("failed to initialise new database: {}", e))?;
+
+        let (mut writer, rx) = db_backend.get_db_write(user_info).await?;
+        writer.write_all(&buf).await?;
+        buf.zeroize();
+        writer.shutdown().await?;
+        if let Some(rx) = rx {
+            rx.await??;
+        }
+
+        Ok(KeePass { config: config.clone(), db })
     }
 
     #[allow(dead_code)]
@@ -135,6 +171,10 @@ impl KeePass {
         }
 
         Ok(())
+    }
+
+    pub(crate) async fn db_key_from_params_pub(db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<DatabaseKey> {
+        Self::db_key_from_params(db_backend, params, user_info).await
     }
 
     async fn db_key_from_params(db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<DatabaseKey> {
@@ -163,6 +203,81 @@ impl KeePass {
         Ok(db_key)
     }
 
+
+    pub fn create_entry(
+        &mut self,
+        group_id: &Uuid,
+        title: &str,
+        username: &str,
+        password: &str,
+        url: &str,
+        notes: &str,
+    ) -> Result<Uuid> {
+        let group = Self::find_group_by_id_mut(&mut self.db.root, group_id)
+            .ok_or(NotFoundError("group"))?;
+
+        let mut entry = KpEntry::new();
+        entry.fields.insert("Title".to_string(), Value::Unprotected(title.to_string()));
+        entry.fields.insert("UserName".to_string(), Value::Unprotected(username.to_string()));
+        if !password.is_empty() {
+            entry.fields.insert("Password".to_string(), Value::Protected(password.as_bytes().into()));
+        }
+        entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
+        entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+
+        let uuid = entry.uuid;
+        group.add_child(entry);
+        Ok(uuid)
+    }
+
+    pub fn update_entry(
+        &mut self,
+        entry_id: &Uuid,
+        title: &str,
+        username: &str,
+        password: &str,
+        url: &str,
+        notes: &str,
+    ) -> Result<()> {
+        let entry = Self::find_entry_by_id_mut(&mut self.db.root, entry_id)
+            .ok_or(NotFoundError("entry"))?;
+
+        entry.fields.insert("Title".to_string(), Value::Unprotected(title.to_string()));
+        entry.fields.insert("UserName".to_string(), Value::Unprotected(username.to_string()));
+        if !password.is_empty() {
+            entry.fields.insert("Password".to_string(), Value::Protected(password.as_bytes().into()));
+        }
+        entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
+        entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+
+        Ok(())
+    }
+
+    pub fn delete_entry(&mut self, entry_id: &Uuid) -> Result<()> {
+        if !Self::remove_entry_from_group(&mut self.db.root, entry_id) {
+            return Err(NotFoundError("entry").into());
+        }
+        Ok(())
+    }
+
+    pub async fn to_backend_with_key(self, db_backend: &mut dyn DbBackend, db_key: DatabaseKey, user_info: &UserInfo) -> Result<()> {
+        let mut buf: Vec<u8> = vec![];
+        let (result, mut buf) = tokio::task::spawn_blocking(move || {
+            let r = self.db.save(&mut buf, db_key);
+            (r, buf)
+        }).await?;
+        result.map_err(|e| anyhow::anyhow!("failed to save database: {}", e))?;
+
+        let (mut writer, rx) = db_backend.get_db_write(user_info).await?;
+        writer.write_all(&buf).await?;
+        buf.zeroize();
+        writer.shutdown().await?;
+        if let Some(rx) = rx {
+            rx.await??;
+        }
+
+        Ok(())
+    }
 
     pub fn get_groups(&self) -> Result<(Group, Option<Uuid>)> {
         let mut last_selected = self.db.meta.last_selected_group;
@@ -322,6 +437,59 @@ impl KeePass {
         }
 
         None
+    }
+
+    fn find_group_by_id_mut<'a>(group: &'a mut KpGroup, id: &Uuid) -> Option<&'a mut KpGroup> {
+        if &group.uuid == id {
+            return Some(group);
+        }
+        for node in &mut group.children {
+            if let Node::Group(g) = node {
+                let found = Self::find_group_by_id_mut(g, id);
+                if found.is_some() {
+                    return found;
+                }
+            }
+        }
+        None
+    }
+
+    fn find_entry_by_id_mut<'a>(group: &'a mut KpGroup, id: &Uuid) -> Option<&'a mut KpEntry> {
+        for node in &mut group.children {
+            match node {
+                Node::Group(g) => {
+                    let found = Self::find_entry_by_id_mut(g, id);
+                    if found.is_some() {
+                        return found;
+                    }
+                }
+                Node::Entry(e) => {
+                    if &e.uuid == id {
+                        return Some(e);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn remove_entry_from_group(group: &mut KpGroup, id: &Uuid) -> bool {
+        let before = group.children.len();
+        group.children.retain(|node| match node {
+            Node::Entry(e) => &e.uuid != id,
+            _ => true,
+        });
+        if group.children.len() < before {
+            return true;
+        }
+        for node in &mut group.children {
+            if let Node::Group(g) = node {
+                if Self::remove_entry_from_group(g, id) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub(crate) fn find_entries_by_string(group: &keepass::db::Group, term: &Regex, config: &Search) -> Vec<Entry> {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -253,6 +253,35 @@ impl KeePass {
         Ok(())
     }
 
+    pub fn create_group(&mut self, parent_id: &Uuid, name: &str) -> Result<Uuid> {
+        // Root accepts unlimited groups. Non-root groups are capped at 2 subgroups,
+        // which also blocks nesting beyond one level below root.
+        if *parent_id != self.db.root.uuid {
+            let parent = Self::find_group_by_id(&self.db.root, parent_id)
+                .ok_or(NotFoundError("group"))?;
+            let subgroup_count = parent.children.iter()
+                .filter(|n| matches!(n, Node::Group(_)))
+                .count();
+            if subgroup_count >= 2 {
+                return Err(anyhow::anyhow!("a group may have at most 2 subgroups"));
+            }
+        }
+
+        let parent = Self::find_group_by_id_mut(&mut self.db.root, parent_id)
+            .ok_or(NotFoundError("group"))?;
+        let group = KpGroup::new(name);
+        let id = group.uuid;
+        parent.children.push(Node::Group(group));
+        Ok(id)
+    }
+
+    pub fn rename_group(&mut self, group_id: &Uuid, name: &str) -> Result<()> {
+        let group = Self::find_group_by_id_mut(&mut self.db.root, group_id)
+            .ok_or(NotFoundError("group"))?;
+        group.name = name.to_string();
+        Ok(())
+    }
+
     pub fn delete_entry(&mut self, entry_id: &Uuid) -> Result<()> {
         if !Self::remove_entry_from_group(&mut self.db.root, entry_id) {
             return Err(NotFoundError("entry").into());

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -9,13 +9,9 @@ use crate::auth::gen_token;
 
 #[cfg(target_os = "linux")]
 mod keyring;
-#[cfg(target_os = "linux")]
-use keyring as store;
 
-#[cfg(any(not(target_os = "linux"), test))]
-mod memory;
-#[cfg(not(target_os = "linux"))]
-use memory as store;
+// always compiled: used on non-linux, in tests, and when use_keyring=false on linux
+pub(super) mod memory;
 
 pub type KeyId = String;
 
@@ -38,6 +34,7 @@ pub struct SecretKey {
     pub key_id: KeyId,
     data: SecretBox<[u8]>,
     timeout: Duration,
+    use_keyring: bool,
 }
 
 impl SecretKey {
@@ -46,23 +43,26 @@ impl SecretKey {
             key_id: gen_token(ID_LENGTH),
             data: SecretBox::new(secret),
             timeout: Duration::default(),
+            use_keyring: false,
         }
     }
 
-    pub fn retrieve(key_id: &KeyId, timeout: Duration) -> Result<Self> {
-        let data = store::retrieve(key_id, timeout)?;
+    pub fn retrieve(key_id: &KeyId, timeout: Duration, use_keyring: bool) -> Result<Self> {
+        let data = Self::dispatch_retrieve(key_id, timeout, use_keyring)?;
 
         Ok(
             Self {
                 key_id: key_id.clone(),
                 data: SecretBox::new(data),
                 timeout,
+                use_keyring,
             }
         )
     }
 
-    pub fn store(&mut self, timeout: Duration) -> Result<&mut Self> {
-        store::store(&self.key_id, self.expose_secret(), timeout)?;
+    pub fn store(&mut self, timeout: Duration, use_keyring: bool) -> Result<&mut Self> {
+        self.use_keyring = use_keyring;
+        Self::dispatch_store(&self.key_id, self.expose_secret(), timeout, use_keyring)?;
 
         self.timeout = timeout;
         Ok(self)
@@ -70,9 +70,51 @@ impl SecretKey {
 
     // retrieve will fail after revoke
     pub fn revoke(&mut self) -> Result<&mut Self> {
-        store::revoke(&self.key_id)?;
+        Self::dispatch_revoke(&self.key_id, self.use_keyring)?;
 
         Ok(self)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_store(key_id: &str, secret: &[u8], timeout: Duration, use_keyring: bool) -> Result<()> {
+        if use_keyring {
+            keyring::store(key_id, secret, timeout)
+        } else {
+            memory::store(key_id, secret, timeout)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_store(key_id: &str, secret: &[u8], timeout: Duration, _use_keyring: bool) -> Result<()> {
+        memory::store(key_id, secret, timeout)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_retrieve(key_id: &str, timeout: Duration, use_keyring: bool) -> Result<Box<[u8]>> {
+        if use_keyring {
+            keyring::retrieve(key_id, timeout)
+        } else {
+            memory::retrieve(key_id, timeout)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_retrieve(key_id: &str, timeout: Duration, _use_keyring: bool) -> Result<Box<[u8]>> {
+        memory::retrieve(key_id, timeout)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_revoke(key_id: &str, use_keyring: bool) -> Result<()> {
+        if use_keyring {
+            keyring::revoke(key_id)
+        } else {
+            memory::revoke(key_id)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_revoke(key_id: &str, _use_keyring: bool) -> Result<()> {
+        memory::revoke(key_id)
     }
 }
 
@@ -95,8 +137,8 @@ mod tests {
     #[test]
     fn key_roundtrip() {
         let mut key = SecretKey::new("some random string !@(as+=!#@_%$".to_string().into_bytes().into_boxed_slice());
-        key.store(Duration::from_secs(10)).unwrap();
-        let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+        key.store(Duration::from_secs(10), false).unwrap();
+        let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10), false).unwrap();
 
         assert_eq!(key.expose_secret(), data.expose_secret());
     }
@@ -106,8 +148,8 @@ mod tests {
     fn key_roundtrip_other_lengths() {
         for secret in [&b"short"[..], &[7u8; 64][..]] {
             let mut key = SecretKey::new(secret.to_vec().into_boxed_slice());
-            key.store(Duration::from_secs(10)).unwrap();
-            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+            key.store(Duration::from_secs(10), false).unwrap();
+            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10), false).unwrap();
 
             assert_eq!(key.expose_secret(), data.expose_secret());
         }

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -101,6 +101,18 @@ mod tests {
         assert_eq!(key.expose_secret(), data.expose_secret());
     }
 
+    // regression: the store must not assume a fixed secret length
+    #[test]
+    fn key_roundtrip_other_lengths() {
+        for secret in [&b"short"[..], &[7u8; 64][..]] {
+            let mut key = SecretKey::new(secret.to_vec().into_boxed_slice());
+            key.store(Duration::from_secs(10)).unwrap();
+            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+
+            assert_eq!(key.expose_secret(), data.expose_secret());
+        }
+    }
+
     #[test]
     fn memory_store_roundtrip_and_revoke() {
         let secret = b"0123456789abcdef0123456789abcdef";

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -1,24 +1,44 @@
+use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::time::Duration;
 
 use anyhow::Result;
-use linux_keyutils::{Key, KeyPermissions, KeyRing, KeyRingIdentifier};
 use secrecy::{ExposeSecret, SecretBox};
 
 use crate::auth::gen_token;
+
+#[cfg(target_os = "linux")]
+mod keyring;
+#[cfg(target_os = "linux")]
+use keyring as store;
+
+#[cfg(any(not(target_os = "linux"), test))]
+mod memory;
+#[cfg(not(target_os = "linux"))]
+use memory as store;
+
+pub type KeyId = String;
+
+const ID_LENGTH: usize = 16;
+
+// returned when a key is missing, expired or revoked - the http layer
+// treats this as 'db closed' rather than a server fault
+#[derive(Debug, Clone)]
+pub struct KeyUnavailableError;
+
+impl Display for KeyUnavailableError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "key not found, expired or revoked")
+    }
+}
+
+impl std::error::Error for KeyUnavailableError {}
 
 pub struct SecretKey {
     pub key_id: KeyId,
     data: SecretBox<[u8]>,
     timeout: Duration,
 }
-
-pub type KeyId = String;
-
-
-const ID_LENGTH: usize = 16;
-const KEYRING_PERM: u32 = 0x3f000000;
-
 
 impl SecretKey {
     pub fn new(secret: Box<[u8]>) -> Self {
@@ -30,31 +50,19 @@ impl SecretKey {
     }
 
     pub fn retrieve(key_id: &KeyId, timeout: Duration) -> Result<Self> {
-        let keyr = get_keyring()?;
+        let data = store::retrieve(key_id, timeout)?;
 
-        let mut k = keyr.search(key_id.as_str())?;
-
-        // TODO: determine buffer size
-        let mut data = vec![0; 32].into_boxed_slice();
-        k.read(&mut data)?;
-
-        let key = Self {
-            key_id: key_id.clone(),
-            data: SecretBox::new(data),
-            timeout,
-        };
-
-        key.update_timeout(&mut k, timeout)?;
-
-        Ok(key)
+        Ok(
+            Self {
+                key_id: key_id.clone(),
+                data: SecretBox::new(data),
+                timeout,
+            }
+        )
     }
 
     pub fn store(&mut self, timeout: Duration) -> Result<&mut Self> {
-        let keyr = get_keyring()?;
-
-        let key = keyr.add_key(self.key_id.as_str(), self.expose_secret())?;
-        key.set_timeout(timeout.as_secs() as usize)?;
-        key.set_perms(KeyPermissions::from_u32(KEYRING_PERM))?;
+        store::store(&self.key_id, self.expose_secret(), timeout)?;
 
         self.timeout = timeout;
         Ok(self)
@@ -62,17 +70,9 @@ impl SecretKey {
 
     // retrieve will fail after revoke
     pub fn revoke(&mut self) -> Result<&mut Self> {
-        let keyr = get_keyring()?;
-
-        let k = keyr.search(self.key_id.as_str())?;
-
-        k.revoke()?;
+        store::revoke(&self.key_id)?;
 
         Ok(self)
-    }
-
-    fn update_timeout(&self, key: &mut Key, timeout: Duration) -> Result<()> {
-        Ok(key.set_timeout(timeout.as_secs() as usize)?)
     }
 }
 
@@ -84,19 +84,13 @@ impl Deref for SecretKey {
     }
 }
 
-fn get_keyring() -> Result<KeyRing> {
-    // TODO: Make other keyrings available
-    // TODO: Investigate why key in Process keyring doesn't persist
-    Ok(KeyRing::from_special_id(KeyRingIdentifier::Session, false)?)
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use secrecy::ExposeSecret;
 
-    use crate::keepass::key::SecretKey;
+    use crate::keepass::key::{memory, SecretKey};
 
     #[test]
     fn key_roundtrip() {
@@ -105,5 +99,25 @@ mod tests {
         let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
 
         assert_eq!(key.expose_secret(), data.expose_secret());
+    }
+
+    #[test]
+    fn memory_store_roundtrip_and_revoke() {
+        let secret = b"0123456789abcdef0123456789abcdef";
+
+        memory::store("test-key", secret, Duration::from_secs(10)).unwrap();
+        let data = memory::retrieve("test-key", Duration::from_secs(10)).unwrap();
+        assert_eq!(data.as_ref(), secret);
+
+        memory::revoke("test-key").unwrap();
+        assert!(memory::retrieve("test-key", Duration::from_secs(10)).is_err());
+    }
+
+    #[test]
+    fn memory_store_expires() {
+        let secret = b"0123456789abcdef0123456789abcdef";
+
+        memory::store("expiring-key", secret, Duration::from_secs(0)).unwrap();
+        assert!(memory::retrieve("expiring-key", Duration::from_secs(10)).is_err());
     }
 }

--- a/src/keepass/key/keyring.rs
+++ b/src/keepass/key/keyring.rs
@@ -22,11 +22,11 @@ pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()
 pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
     let keyr = get_keyring()?;
 
-    let mut key = keyr.search(key_id).map_err(map_err)?;
+    let key = keyr.search(key_id).map_err(map_err)?;
 
-    // TODO: determine buffer size
-    let mut data = vec![0; 32].into_boxed_slice();
-    key.read(&mut data).map_err(map_err)?;
+    // read the actual payload length instead of assuming 32 bytes,
+    // so secrets of any length roundtrip unchanged
+    let data = key.read_to_vec().map_err(map_err)?.into_boxed_slice();
 
     key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
 

--- a/src/keepass/key/keyring.rs
+++ b/src/keepass/key/keyring.rs
@@ -1,0 +1,56 @@
+// linux kernel keyring backed key store
+
+use std::time::Duration;
+
+use anyhow::Result;
+use linux_keyutils::{KeyError, KeyPermissions, KeyRing, KeyRingIdentifier};
+
+use super::KeyUnavailableError;
+
+const KEYRING_PERM: u32 = 0x3f000000;
+
+pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()> {
+    let keyr = get_keyring()?;
+
+    let key = keyr.add_key(key_id, secret).map_err(map_err)?;
+    key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
+    key.set_perms(KeyPermissions::from_u32(KEYRING_PERM)).map_err(map_err)?;
+
+    Ok(())
+}
+
+pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
+    let keyr = get_keyring()?;
+
+    let mut key = keyr.search(key_id).map_err(map_err)?;
+
+    // TODO: determine buffer size
+    let mut data = vec![0; 32].into_boxed_slice();
+    key.read(&mut data).map_err(map_err)?;
+
+    key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
+
+    Ok(data)
+}
+
+pub(super) fn revoke(key_id: &str) -> Result<()> {
+    let keyr = get_keyring()?;
+
+    let key = keyr.search(key_id).map_err(map_err)?;
+    key.revoke().map_err(map_err)?;
+
+    Ok(())
+}
+
+fn map_err(err: KeyError) -> anyhow::Error {
+    match err {
+        KeyError::KeyDoesNotExist | KeyError::KeyExpired | KeyError::KeyRevoked => KeyUnavailableError.into(),
+        err => anyhow::Error::new(err),
+    }
+}
+
+fn get_keyring() -> Result<KeyRing> {
+    // TODO: Make other keyrings available
+    // TODO: Investigate why key in Process keyring doesn't persist
+    Ok(KeyRing::from_special_id(KeyRingIdentifier::Session, false)?)
+}

--- a/src/keepass/key/memory.rs
+++ b/src/keepass/key/memory.rs
@@ -1,0 +1,64 @@
+// in-memory key store for platforms without kernel keyrings.
+// keys stay in (zeroized-on-drop) process memory instead of the kernel,
+// which is weaker than the linux keyring but enables native macos/windows runs.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use zeroize::Zeroize;
+
+use super::KeyUnavailableError;
+
+struct Entry {
+    secret: Vec<u8>,
+    expiry: Instant,
+}
+
+impl Drop for Entry {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+fn entries() -> &'static Mutex<HashMap<String, Entry>> {
+    static STORE: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+    STORE.get_or_init(Default::default)
+}
+
+pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()> {
+    let mut store = entries().lock().unwrap();
+
+    // drop expired keys so the map doesn't grow unboundedly
+    let now = Instant::now();
+    store.retain(|_, entry| now < entry.expiry);
+
+    store.insert(key_id.to_string(), Entry {
+        secret: secret.to_vec(),
+        expiry: now + timeout,
+    });
+
+    Ok(())
+}
+
+pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
+    let mut store = entries().lock().unwrap();
+
+    let entry = store.get_mut(key_id).ok_or(KeyUnavailableError)?;
+    if Instant::now() >= entry.expiry {
+        store.remove(key_id);
+        return Err(KeyUnavailableError.into());
+    }
+
+    entry.expiry = Instant::now() + timeout;
+    Ok(entry.secret.clone().into_boxed_slice())
+}
+
+pub(super) fn revoke(key_id: &str) -> Result<()> {
+    entries().lock().unwrap()
+        .remove(key_id)
+        .ok_or(KeyUnavailableError)?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod server;
 mod auth;
 mod keepass;
+mod rate_limit;
 mod session;
 
 const CONFIG_FILE: &str = "config.yml";

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ const CONFIG_FILE: &str = "config.yml";
 struct Args {
     #[arg(short, long, default_value = CONFIG_FILE)]
     config: std::path::PathBuf,
+    /// probe /health of a running instance and exit (for container healthchecks)
+    #[arg(long)]
+    health_check: bool,
 }
 
 #[actix_web::main]
@@ -26,6 +29,38 @@ async fn main() {
     let args = Args::parse();
     let config = Config::from_file(args.config).expect("Failed to parse config");
 
+    if args.health_check {
+        std::process::exit(health_check(config.port));
+    }
+
     Server::new(config)
         .await.expect("Failed to start server")
+}
+
+// minimal http probe without a shell or curl, usable from a scratch image
+fn health_check(port: u16) -> i32 {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let timeout = Duration::from_secs(3);
+    for addr in ["127.0.0.1", "::1"] {
+        let Ok(mut stream) = TcpStream::connect((addr, port)) else {
+            continue;
+        };
+        let _ = stream.set_read_timeout(Some(timeout));
+        let _ = stream.set_write_timeout(Some(timeout));
+
+        let request = format!("GET {} HTTP/1.0\r\nHost: localhost\r\n\r\n", server::route::ROUTE_HEALTH);
+        if stream.write_all(request.as_bytes()).is_err() {
+            continue;
+        }
+
+        let mut response = String::new();
+        if stream.read_to_string(&mut response).is_ok() && response.starts_with("HTTP/1.0 200") {
+            return 0;
+        }
+    }
+
+    1
 }

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+// failures before lockouts start
+const FREE_FAILURES: u32 = 5;
+const BASE_DELAY: Duration = Duration::from_secs(2);
+const MAX_DELAY: Duration = Duration::from_secs(15 * 60);
+
+struct Failures {
+    count: u32,
+    last_failure: Instant,
+}
+
+impl Failures {
+    fn blocked_until(&self) -> Option<Instant> {
+        if self.count <= FREE_FAILURES {
+            return None;
+        }
+        // exponential backoff: 2s, 4s, 8s, ... capped at 15 minutes
+        let exponent = (self.count - FREE_FAILURES - 1).min(30);
+        let delay = BASE_DELAY.saturating_mul(2u32.saturating_pow(exponent)).min(MAX_DELAY);
+        Some(self.last_failure + delay)
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.last_failure) > MAX_DELAY
+    }
+}
+
+// in-memory login throttle with exponential backoff,
+// keyed by caller-provided strings (e.g. "<ip>|<username>")
+#[derive(Default)]
+pub struct RateLimiter {
+    entries: Mutex<HashMap<String, Failures>>,
+}
+
+impl RateLimiter {
+    // remaining lockout, if the key is currently blocked
+    pub async fn check(&self, key: &str) -> Option<Duration> {
+        let entries = self.entries.lock().await;
+        let blocked_until = entries.get(key)?.blocked_until()?;
+        let now = Instant::now();
+        if now < blocked_until {
+            return Some(blocked_until - now);
+        }
+        None
+    }
+
+    pub async fn failure(&self, key: &str) {
+        let mut entries = self.entries.lock().await;
+
+        // drop stale entries so the map doesn't grow unboundedly
+        let now = Instant::now();
+        entries.retain(|_, f| !f.expired(now));
+
+        let failures = entries.entry(key.to_string()).or_insert(Failures {
+            count: 0,
+            last_failure: now,
+        });
+        failures.count += 1;
+        failures.last_failure = now;
+    }
+
+    pub async fn success(&self, key: &str) {
+        self.entries.lock().await.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn blocks_after_free_failures() {
+        let limiter = RateLimiter::default();
+        let key = "1.2.3.4|alice";
+
+        for _ in 0..FREE_FAILURES {
+            limiter.failure(key).await;
+            assert!(limiter.check(key).await.is_none());
+        }
+
+        limiter.failure(key).await;
+        assert!(limiter.check(key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn success_resets() {
+        let limiter = RateLimiter::default();
+        let key = "1.2.3.4|alice";
+
+        for _ in 0..FREE_FAILURES + 3 {
+            limiter.failure(key).await;
+        }
+        assert!(limiter.check(key).await.is_some());
+
+        limiter.success(key).await;
+        assert!(limiter.check(key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn keys_are_independent() {
+        let limiter = RateLimiter::default();
+
+        for _ in 0..FREE_FAILURES + 1 {
+            limiter.failure("1.2.3.4|alice").await;
+        }
+        assert!(limiter.check("1.2.3.4|alice").await.is_some());
+        assert!(limiter.check("5.6.7.8|alice").await.is_none());
+        assert!(limiter.check("1.2.3.4|bob").await.is_none());
+    }
+
+    #[test]
+    fn backoff_escalates_and_caps() {
+        let now = Instant::now();
+        let delay = |count| Failures { count, last_failure: now }
+            .blocked_until()
+            .map(|until| until - now);
+
+        assert_eq!(delay(FREE_FAILURES), None);
+        assert_eq!(delay(FREE_FAILURES + 1), Some(Duration::from_secs(2)));
+        assert_eq!(delay(FREE_FAILURES + 2), Some(Duration::from_secs(4)));
+        assert_eq!(delay(FREE_FAILURES + 3), Some(Duration::from_secs(8)));
+        assert_eq!(delay(FREE_FAILURES + 100), Some(MAX_DELAY));
+    }
+}

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -1,6 +1,7 @@
 use actix_files as fs;
 use actix_files::NamedFile;
-use actix_web::{Responder, web};
+use actix_web::{HttpResponse, Responder, web};
+use serde_json::json;
 
 use crate::server::route::auth::{
     authenticated,
@@ -28,6 +29,7 @@ pub mod util;
 pub const API_PATH: &str = "/api/v1";
 pub const STATIC_PATH: &str = "/assets";
 pub const INDEX_FILE: &str = "public/index.html";
+pub const ROUTE_HEALTH: &str = "/health";
 
 pub fn setup_routes(cfg: &mut web::ServiceConfig) {
     cfg
@@ -52,6 +54,9 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
 
         .service(callback_user_auth)
 
+        // unauthenticated liveness probe
+        .route(ROUTE_HEALTH, web::get().to(health))
+
         // static
         .route("/", web::get().to(index))
         .route("/keepass", web::get().to(index))
@@ -64,5 +69,13 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
 
 async fn index() -> impl Responder {
     NamedFile::open_async(INDEX_FILE).await
+}
+
+async fn health() -> impl Responder {
+    HttpResponse::Ok().json(json!(
+        {
+            "status": "ok",
+        }
+    ))
 }
 

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -10,9 +10,12 @@ use crate::server::route::auth::{
     close_db,
     db_login,
     logout,
+    save_db,
     user_login,
 };
 use crate::server::route::keepass::{
+    create_entry,
+    delete_entry,
     get_entry,
     get_file,
     get_group_entries,
@@ -20,6 +23,7 @@ use crate::server::route::keepass::{
     get_icon,
     get_protected,
     search_entries,
+    update_entry,
 };
 
 pub mod auth;
@@ -41,6 +45,7 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(db_login)
             .service(close_db)
             .service(logout)
+            .service(save_db)
 
             // keepass
             .service(get_groups)
@@ -50,6 +55,9 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(get_file)
             .service(search_entries)
             .service(get_icon)
+            .service(create_entry)
+            .service(update_entry)
+            .service(delete_entry)
         )
 
         .service(callback_user_auth)

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -15,6 +15,7 @@ use crate::server::route::auth::{
 };
 use crate::server::route::keepass::{
     create_entry,
+    create_group,
     delete_entry,
     get_entry,
     get_file,
@@ -22,6 +23,7 @@ use crate::server::route::keepass::{
     get_groups,
     get_icon,
     get_protected,
+    rename_group,
     search_entries,
     update_entry,
 };
@@ -58,6 +60,8 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(create_entry)
             .service(update_entry)
             .service(delete_entry)
+            .service(create_group)
+            .service(rename_group)
         )
 
         .service(callback_user_auth)

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -191,7 +191,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         error!("db login from '{}': failed to store key: {}", username, err);
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store key",
             }
         ));
@@ -204,7 +204,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         }
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store db",
             }
         ));
@@ -221,7 +221,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
 fn get_user_info(session: &Session) -> Result<UserInfo, HttpResponse> {
     let resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to retrieve session",
         }
     ));

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -344,7 +344,7 @@ async fn embed_in_index(success: bool, message: Option<String>, data: Option<Ses
     let mut index = match tokio::fs::read_to_string(INDEX_FILE).await {
         Ok(v) => v,
         Err(err) => {
-            info!("user login from '{}': ", err);
+            error!("failed to read index file: {}", err);
             return HttpResponse::InternalServerError().json(json!(
                 {
                     "success": false,

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -60,7 +60,13 @@ async fn user_login(request: HttpRequest, session: Session, config: Data<Config>
         return err;
     }
 
-    let client_ip = request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string();
+    // forwarding headers are spoofable, only honor them when explicitly
+    // configured (i.e. behind a reverse proxy that sets them)
+    let client_ip = if config.trust_proxy_headers {
+        request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string()
+    } else {
+        request.peer_addr().map(|addr| addr.ip().to_string()).unwrap_or_else(|| "unknown".to_string())
+    };
     let rate_key = format!("{}|{}", client_ip, params.username.to_lowercase());
     if let Some(remaining) = rate_limiter.check(&rate_key).await {
         info!("user login from '{}' ({}): rate limited for {}s", params.username, client_ip, remaining.as_secs());

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -12,6 +12,7 @@ use crate::auth_backend::{AuthCache, SESSION_KEY_AUTH_STATE, UserInfo};
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::KeePass;
+use crate::rate_limit::RateLimiter;
 use crate::server::route::INDEX_FILE;
 use crate::server::route::util::{_close_db, check_user_session, db_is_open, revoke_key, set_user_session, store_key};
 use crate::session::AuthSession;
@@ -54,9 +55,21 @@ async fn authenticated(session: Session, config: Data<Config>, db_cache: Data<Db
 
 
 #[post("/user_login")]
-async fn user_login(session: Session, config: Data<Config>, params: web::Form<UserLogin>) -> impl Responder {
+async fn user_login(request: HttpRequest, session: Session, config: Data<Config>, rate_limiter: Data<RateLimiter>, params: web::Form<UserLogin>) -> impl Responder {
     if let Err(err) = check_user_session(&session, &params.username) {
         return err;
+    }
+
+    let client_ip = request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string();
+    let rate_key = format!("{}|{}", client_ip, params.username.to_lowercase());
+    if let Some(remaining) = rate_limiter.check(&rate_key).await {
+        info!("user login from '{}' ({}): rate limited for {}s", params.username, client_ip, remaining.as_secs());
+        return HttpResponse::TooManyRequests().json(json!(
+            {
+                "success": false,
+                "message": "too many failed login attempts, try again later",
+            }
+        ));
     }
 
     let auth_backend = auth_backend::new(&config);
@@ -64,6 +77,7 @@ async fn user_login(session: Session, config: Data<Config>, params: web::Form<Us
     let user_info = match auth_backend.login(params.username.as_str(), params.password.as_str()).await {
         Ok(user_info) => user_info,
         Err(err) => {
+            rate_limiter.failure(&rate_key).await;
             info!("user login from '{}': {}", params.username, err);
             return HttpResponse::Unauthorized().json(json!(
                 {
@@ -73,6 +87,7 @@ async fn user_login(session: Session, config: Data<Config>, params: web::Form<Us
             ));
         }
     };
+    rate_limiter.success(&rate_key).await;
 
     let csrf_token = match set_user_session(session, &user_info) {
         Ok(v) => v,

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -14,7 +14,7 @@ use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::KeePass;
 use crate::rate_limit::RateLimiter;
 use crate::server::route::INDEX_FILE;
-use crate::server::route::util::{_close_db, check_user_session, db_is_open, revoke_key, set_user_session, store_key};
+use crate::server::route::util::{_close_db, check_user_session, db_is_open, get_db, revoke_key, set_user_session, store_key};
 use crate::session::AuthSession;
 
 #[derive(Serialize)]
@@ -179,8 +179,8 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         Err(err) => return err,
     };
 
-    let db_backend = db_backend::new(&config);
-    let db = match KeePass::from_backend(&config, db_backend.as_ref(), &params, &user_info).await {
+    let mut db_backend = db_backend::new(&config);
+    let db = match KeePass::from_backend(&config, db_backend.as_mut(), &params, &user_info).await {
         Ok(v) => v,
         Err(err) => {
             info!("db login from '{}': {}", username, err);
@@ -306,6 +306,44 @@ async fn logout(request: HttpRequest, session: Session, config: Data<Config>, db
             "data": logout_type,
         }
     ))
+}
+
+#[post("/save_db")]
+async fn save_db(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<DbLogin>) -> impl Responder {
+    let username = session.get_user_id();
+
+    let keepass = match get_db(&session, &config, &db_cache).await {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
+
+    let user_info = match get_user_info(&session) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
+
+    let mut db_backend = db_backend::new(&config);
+    let db_key = match KeePass::db_key_from_params_pub(db_backend.as_ref(), &params, &user_info).await {
+        Ok(k) => k,
+        Err(err) => {
+            info!("save_db from '{}': {}", username, err);
+            return HttpResponse::Unauthorized().json(json!({
+                "success": false,
+                "message": "incorrect key",
+            }));
+        }
+    };
+
+    if let Err(err) = keepass.to_backend_with_key(db_backend.as_mut(), db_key, &user_info).await {
+        error!("save_db from '{}': {}", username, err);
+        return HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to save database",
+        }));
+    }
+
+    info!("save_db from '{}': successful", username);
+    HttpResponse::Ok().json(json!({ "success": true }))
 }
 
 #[get("/callback_user_auth")]

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -279,7 +279,7 @@ async fn logout(request: HttpRequest, session: Session, config: Data<Config>, db
     };
 
     let host = format!("{}://{}", request.connection_info().scheme(), request.connection_info().host());
-    let logout_type = match auth_backend::new(&config).get_logout_type(&user_info, &host, &auth_cache) {
+    let logout_type = match auth_backend::new(&config).get_logout_type(&user_info, &host, &auth_cache).await {
         Ok(logout_type) => logout_type,
         Err(err) => {
             error!("failed to determine logout type: {}", err);

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -133,26 +133,17 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
 
 #[get("/get_file")]
 async fn get_file(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Query<File>) -> impl Responder {
-    let keepass = match util::get_db(&session, &config, &db_cache).await {
-        Ok(v) => v,
-        Err(err) => return err,
+    if let Err(err) = util::get_db(&session, &config, &db_cache).await {
+        return err;
     };
 
-    let username = session.get_user_id();
-    let file = match keepass.get_file(&params) {
-        Ok(v) => v,
-        Err(err) => {
-            info!("{}: failed to get file '{}' of entry '{}': {}", username, params.filename, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get file",
-                }
-            ));
+    info!("{}: file download requested for '{}' of entry '{}', but it is not implemented", session.get_user_id(), params.filename, params.entry_id);
+    HttpResponse::NotImplemented().json(json!(
+        {
+            "success": false,
+            "message": "file download is not implemented yet",
         }
-    };
-
-    HttpResponse::Ok().body(file)
+    ))
 }
 
 #[get("/search_entries")]

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -1,15 +1,37 @@
 use actix_session::Session;
-use actix_web::{get, HttpResponse, Responder, web};
+use actix_web::{delete, get, post, put, HttpResponse, Responder, web};
 use actix_web::web::Data;
 use log::info;
+use serde::Deserialize;
 use serde_json::json;
 use secrecy::ExposeSecret;
+use uuid::Uuid;
 
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::{File, Id, NotFoundError, Protected, SearchTerm};
 use crate::server::route::util;
 use crate::session::AuthSession;
+
+#[derive(Deserialize)]
+struct NewEntry {
+    group_id: Uuid,
+    title: String,
+    username: String,
+    password: String,
+    url: String,
+    notes: String,
+}
+
+#[derive(Deserialize)]
+struct UpdateEntry {
+    id: Uuid,
+    title: String,
+    username: String,
+    password: String,
+    url: String,
+    notes: String,
+}
 
 // 404 for missing entries/groups/icons, 500 for everything else
 fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
@@ -215,6 +237,64 @@ fn icon_mime(data: &[u8]) -> &'static str {
         // previous behavior, custom icons are usually png
         "image/png"
     }
+}
+
+#[post("/entry")]
+async fn create_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<NewEntry>) -> impl Responder {
+    let username = session.get_user_id();
+    let mut new_id = Uuid::nil();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        new_id = kp.create_entry(
+            &params.group_id,
+            &params.title,
+            &params.username,
+            &params.password,
+            &params.url,
+            &params.notes,
+        )?;
+        Ok(())
+    }).await {
+        return err;
+    }
+
+    info!("create_entry from '{}': {}", username, new_id);
+    HttpResponse::Ok().json(json!({ "success": true, "data": { "id": new_id } }))
+}
+
+#[put("/entry")]
+async fn update_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<UpdateEntry>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.update_entry(
+            &params.id,
+            &params.title,
+            &params.username,
+            &params.password,
+            &params.url,
+            &params.notes,
+        )
+    }).await {
+        return err;
+    }
+
+    info!("update_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
+}
+
+#[delete("/entry")]
+async fn delete_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Query<Id>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.delete_entry(&params.id)
+    }).await {
+        return err;
+    }
+
+    info!("delete_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
 }
 
 #[cfg(test)]

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -2,15 +2,28 @@ use actix_session::Session;
 use actix_web::{get, HttpResponse, Responder, web};
 use actix_web::web::Data;
 use log::info;
-use mime::IMAGE_PNG;
 use serde_json::json;
 use secrecy::ExposeSecret;
 
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
-use crate::keepass::keepass::{File, Id, Protected, SearchTerm};
+use crate::keepass::keepass::{File, Id, NotFoundError, Protected, SearchTerm};
 use crate::server::route::util;
 use crate::session::AuthSession;
+
+// 404 for missing entries/groups/icons, 500 for everything else
+fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
+    let resp = json!(
+        {
+            "success": false,
+            "message": message,
+        }
+    );
+    if err.downcast_ref::<NotFoundError>().is_some() {
+        return HttpResponse::NotFound().json(resp);
+    }
+    HttpResponse::InternalServerError().json(resp)
+}
 
 #[get("/get_groups")]
 async fn get_groups(session: Session, config: Data<Config>, db_cache: Data<DbCache>) -> impl Responder {
@@ -56,12 +69,7 @@ async fn get_group_entries(session: Session, config: Data<Config>, db_cache: Dat
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entries for group '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get group entries",
-                }
-            ));
+            return error_response(&err, "failed to get group entries");
         }
     };
 
@@ -85,12 +93,7 @@ async fn get_entry(session: Session, config: Data<Config>, db_cache: Data<DbCach
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entry '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get entry",
-                }
-            ));
+            return error_response(&err, "failed to get entry");
         }
     };
 
@@ -114,12 +117,7 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get protected '{}' of entry '{}': {}", username, params.name, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get protected field",
-                }
-            ));
+            return error_response(&err, "failed to get protected field");
         }
     };
 
@@ -192,22 +190,53 @@ async fn get_icon(session: Session, config: Data<Config>, db_cache: Data<DbCache
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get icon '{}': {}", username, params.id, err);
-            // TODO: Serve 404 if icon not found
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get icon",
-                }
-            ));
+            return error_response(&err, "failed to get icon");
         }
     };
 
     HttpResponse::Ok()
         // UUID is unique, cache this forever
-        .append_header(("Cache-Control", "max-age=31536000; public; s-max-age=31536000"))
+        .append_header(("Cache-Control", "public, max-age=31536000, s-maxage=31536000, immutable"))
         .append_header(("ETag", icon.uuid.to_string()))
-        // TODO: sniff content type?
-        .content_type(IMAGE_PNG)
+        .content_type(icon_mime(&icon.data))
         .body(icon.data.clone())
+}
+
+fn icon_mime(data: &[u8]) -> &'static str {
+    if data.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "image/png"
+    } else if data.starts_with(b"\xff\xd8\xff") {
+        "image/jpeg"
+    } else if data.starts_with(b"GIF8") {
+        "image/gif"
+    } else if data.starts_with(b"<svg") || data.starts_with(b"<?xml") {
+        "image/svg+xml"
+    } else {
+        // previous behavior, custom icons are usually png
+        "image/png"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_mime_detection() {
+        assert_eq!(icon_mime(b"\x89PNG\r\n\x1a\nrest"), "image/png");
+        assert_eq!(icon_mime(b"\xff\xd8\xff\xe0rest"), "image/jpeg");
+        assert_eq!(icon_mime(b"GIF89a"), "image/gif");
+        assert_eq!(icon_mime(b"<svg xmlns="), "image/svg+xml");
+        assert_eq!(icon_mime(b"unknown"), "image/png");
+    }
+
+    #[test]
+    fn not_found_maps_to_404() {
+        let err: anyhow::Error = NotFoundError("entry").into();
+        assert_eq!(error_response(&err, "msg").status(), 404);
+
+        let err = anyhow::anyhow!("other");
+        assert_eq!(error_response(&err, "msg").status(), 500);
+    }
 }
 

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -33,6 +33,18 @@ struct UpdateEntry {
     notes: String,
 }
 
+#[derive(Deserialize)]
+struct NewGroup {
+    parent_id: Uuid,
+    title: String,
+}
+
+#[derive(Deserialize)]
+struct RenameGroup {
+    id: Uuid,
+    title: String,
+}
+
 // 404 for missing entries/groups/icons, 500 for everything else
 fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
     let resp = json!(
@@ -280,6 +292,36 @@ async fn update_entry(session: Session, config: Data<Config>, db_cache: Data<DbC
     }
 
     info!("update_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
+}
+
+#[post("/group")]
+async fn create_group(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<NewGroup>) -> impl Responder {
+    let username = session.get_user_id();
+    let mut new_id = Uuid::nil();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        new_id = kp.create_group(&params.parent_id, &params.title)?;
+        Ok(())
+    }).await {
+        return err;
+    }
+
+    info!("create_group from '{}': {} under {}", username, params.title, params.parent_id);
+    HttpResponse::Ok().json(json!({ "success": true, "data": { "id": new_id } }))
+}
+
+#[put("/group")]
+async fn rename_group(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<RenameGroup>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.rename_group(&params.id, &params.title)
+    }).await {
+        return err;
+    }
+
+    info!("rename_group from '{}': {} -> '{}'", username, params.id, params.title);
     HttpResponse::Ok().json(json!({ "success": true }))
 }
 

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -66,7 +66,7 @@ pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow
 pub(crate) async fn _close_db(session: &Session, config: &Config, db_cache: &DbCache) -> Result<(), HttpResponse> {
     let err_resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to close db",
         }
     ));

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -1,7 +1,6 @@
 use actix_session::Session;
 use actix_web::HttpResponse;
 use anyhow::{anyhow, bail};
-use linux_keyutils::KeyError;
 use log::{error, info};
 use serde_json::json;
 
@@ -10,7 +9,7 @@ use crate::auth_backend::UserInfo;
 use crate::config::config::Config;
 use crate::keepass::db_cache::{CacheExpiredError, DbCache};
 use crate::keepass::keepass::KeePass;
-use crate::keepass::key::{KeyId, SecretKey};
+use crate::keepass::key::{KeyId, KeyUnavailableError, SecretKey};
 use crate::session::AuthSession;
 
 pub const SESSION_KEY_KEY_ID: &str = "key_id";
@@ -125,7 +124,7 @@ pub(crate) async fn get_db(session: &Session, config: &Config, db_cache: &DbCach
                 }
             );
 
-            return match err.downcast_ref::<KeyError>() {
+            return match err.downcast_ref::<KeyUnavailableError>() {
                 Some(_) => {
                     _close_db(session, config, db_cache).await?;
 
@@ -197,12 +196,9 @@ pub(crate) fn revoke_key(config: &Config, session: &Session) -> anyhow::Result<(
 fn check_key_err<F>(ok: F, err: anyhow::Error) -> anyhow::Result<()>
     where F: Fn() -> anyhow::Result<()>
 {
-    match err.downcast_ref::<KeyError>() {
-        Some(e) => match e {
-            // Ignore non-existent, expired or already revoked
-            KeyError::KeyDoesNotExist | KeyError::KeyExpired | KeyError::KeyRevoked => ok(),
-            _ => Err(err),
-        }
+    // Ignore non-existent, expired or already revoked
+    match err.downcast_ref::<KeyUnavailableError>() {
+        Some(_) => ok(),
         None => Err(err),
     }
 }

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -47,6 +47,9 @@ pub(crate) fn check_user_session(session: &Session, username: &str) -> Result<()
 }
 
 pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow::Result<CsrfToken> {
+    // rotate the session on privilege change to prevent session fixation
+    session.renew();
+
     if let Err(err) = session.insert(SESSION_KEY_USER, user_info) {
         session.destroy();
         error!("user login from '{}': {}", user_info.id, err);

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -162,6 +162,60 @@ pub(crate) async fn db_is_open(session: &Session, config: &Config, db_cache: &Db
     Ok(true)
 }
 
+/// Decrypt the cached database, run `modify`, then re-encrypt and store back.
+/// The old session key is revoked and replaced with a fresh one.
+pub(crate) async fn modify_db<F>(
+    session: &Session,
+    config: &Config,
+    db_cache: &DbCache,
+    modify: F,
+) -> Result<(), HttpResponse>
+where
+    F: FnOnce(&mut KeePass) -> anyhow::Result<()>,
+{
+    let mut keepass = get_db(session, config, db_cache).await?;
+
+    if let Err(err) = modify(&mut keepass) {
+        return Err(HttpResponse::UnprocessableEntity().json(json!({
+            "success": false,
+            "message": err.to_string(),
+        })));
+    }
+
+    let (new_key, new_enc) = match keepass.to_enc() {
+        Ok(v) => v,
+        Err(err) => {
+            error!("failed to re-encrypt database after modification: {}", err);
+            return Err(HttpResponse::InternalServerError().json(json!({
+                "success": false,
+                "message": "failed to encrypt database",
+            })));
+        }
+    };
+
+    // Revoke the old key before storing the new one so it is replaced atomically
+    // from the session's perspective (the old key_id is still in the session here).
+    let _ = revoke_key(config, session);
+
+    if let Err(err) = store_key(config, session, new_key) {
+        error!("failed to store new key after modification: {}", err);
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to store key",
+        })));
+    }
+
+    if let Err(err) = db_cache.store(session, new_enc).await {
+        error!("failed to store modified database: {}", err);
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to store database",
+        })));
+    }
+
+    Ok(())
+}
+
 pub(crate) fn retrieve_key(config: &Config, session: &Session) -> anyhow::Result<SecretKey> {
     let key_id = session.get::<KeyId>(SESSION_KEY_KEY_ID)?
         .ok_or(anyhow!("failed to retrieve key id from session"))?;

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -166,11 +166,11 @@ pub(crate) fn retrieve_key(config: &Config, session: &Session) -> anyhow::Result
     let key_id = session.get::<KeyId>(SESSION_KEY_KEY_ID)?
         .ok_or(anyhow!("failed to retrieve key id from session"))?;
 
-    SecretKey::retrieve(&key_id, config.db_session_timeout)
+    SecretKey::retrieve(&key_id, config.db_session_timeout, config.use_keyring)
 }
 
 pub(crate) fn store_key(config: &Config, session: &Session, mut key: SecretKey) -> anyhow::Result<()> {
-    key.store(config.db_session_timeout)?;
+    key.store(config.db_session_timeout, config.use_keyring)?;
     session.insert(SESSION_KEY_KEY_ID, key.key_id)?;
 
     Ok(())

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -8,6 +8,7 @@ use env_logger::Env;
 use crate::{auth, auth_backend};
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
+use crate::rate_limit::RateLimiter;
 use crate::server::route::setup_routes;
 
 pub struct Server;
@@ -22,11 +23,13 @@ impl Server {
         let config_data = web::Data::new(config);
         let auth_cache = web::Data::new(auth_backend::new(&config_data).init().await?);
         let db_cache = web::Data::new(DbCache::default());
+        let rate_limiter = web::Data::new(RateLimiter::default());
 
         HttpServer::new(move || {
             App::new()
                 .app_data(db_cache.clone())
                 .app_data(auth_cache.clone())
+                .app_data(rate_limiter.clone())
                 .app_data(config_data.clone())
                 .wrap(auth::CheckAuth)
                 .wrap(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,7 +1,7 @@
 use actix_session::{config::PersistentSession, SessionMiddleware, storage::CookieSessionStore};
 use actix_web::{App, HttpServer, web};
 use actix_web::cookie::time::Duration;
-use actix_web::middleware::Logger;
+use actix_web::middleware::{DefaultHeaders, Logger};
 use anyhow::Result;
 use env_logger::Env;
 
@@ -45,6 +45,16 @@ impl Server {
                         .build(),
                 )
                 .wrap(Logger::default())
+                // registered last = outermost, so the headers are also set on
+                // responses short-circuited by the middlewares above.
+                // CSP is omitted for now: the index page relies on
+                // inline script injection (see embed_in_index)
+                .wrap(
+                    DefaultHeaders::new()
+                        .add(("X-Frame-Options", "DENY"))
+                        .add(("X-Content-Type-Options", "nosniff"))
+                        .add(("Referrer-Policy", "no-referrer"))
+                )
                 .configure(setup_routes)
         }).bind((server, port))?
             .run()

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -1,0 +1,42 @@
+{
+  "realm": "keepass",
+  "enabled": true,
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "keepass4web",
+      "name": "KeePass4Web",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "insecure-example-client-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/callback_user_auth",
+        "http://127.0.0.1:8080/callback_user_auth"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "testuser@example.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -15,10 +15,15 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [
         "http://localhost:8080/callback_user_auth",
-        "http://127.0.0.1:8080/callback_user_auth"
+        "http://127.0.0.1:8080/callback_user_auth",
+        "http://localhost:8088/callback_user_auth",
+        "http://127.0.0.1:8088/callback_user_auth",
+        "http://keycloak:8088/callback_user_auth"
       ],
       "webOrigins": [
-        "http://localhost:8080"
+        "http://localhost:8080",
+        "http://localhost:8088",
+        "http://keycloak:8088"
       ]
     }
   ],


### PR DESCRIPTION
Closes #320
Closes #322

## Summary

**Commit 1 — OIDC Docker split-brain fix + auto-create KDBX + entry CRUD**

- `discovery_url` config field fetches OIDC metadata from an internal Docker URL; server-side endpoints (`token_endpoint`, `jwks_uri`, etc.) are rewritten to use the internal host so the app container can reach Keycloak via Docker DNS while browsers use the public hostname.
- Explicit JWKS fetch: `openidconnect` marks the JWKS `#[serde(skip)]`, so it is fetched separately and injected via `set_jwks()`.
- Auto-create KDBX: if the configured `.kdbx` path does not exist on first unlock, an empty KDBX4 database is created automatically on the server.
- Entry CRUD: `POST/PUT/DELETE /api/v1/entry` backed by a `modify_db()` helper that handles decrypt→modify→re-encrypt→key-rotation. `POST /api/v1/save_db` writes the database to disk (requires master password).
- Frontend: "New Entry" inline form with password generate/show-hide, per-row delete button, Save floppy-disk button in navbar.

**Commit 2 — UUID fix + password UX**

- `EntryGroup` was missing its own `id` field, causing `group_id` to be sent as `"undefined"` when creating an entry (UUID parse error on server).
- Search results use `Uuid::nil()` as sentinel; "New Entry" / "Add Group" are hidden for search result views.

**Commit 3 — Group create/rename + entry edit + depth limit**

- `POST /api/v1/group` — create a named subgroup; `PUT /api/v1/group` — rename a group.
- Depth rule: root accepts unlimited child groups; any non-root group is capped at **2 subgroups** (backend 422 if exceeded). "Add Group" button hidden in UI at depth ≥ 2.
- Entry edit: inline pre-filled form per row (pencil icon); blank password keeps existing protected value.

## Test plan

- [ ] OIDC login works in Docker Compose with split `discovery_url` / `issuer`
- [ ] Fresh deploy with no `.kdbx` → database auto-created on first unlock
- [ ] Create entry → appears in list; delete entry → disappears; save to disk → file persists
- [ ] Select root → "Add Group" visible, unlimited children
- [ ] Select depth-1 group → "Add Group" visible, max 2 subgroups; 3rd attempt returns error
- [ ] Select depth-2 group → "Add Group" hidden
- [ ] Rename group → title updates in panel header and tree sidebar instantly
- [ ] Edit entry → form pre-filled; blank password keeps existing; new password updates it