### PR TITLE
feat: modern three-panel UI redesign with dark theme and icon picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment for the optional auth test services in docker-compose.yml.
+# Copy to .env (docker compose loads it automatically) and adjust as needed:
+#   cp .env.example .env
+# These are throwaway example values for local testing only.
+
+### OpenLDAP (auth_backend: LDAP) ###
+LDAP_ROOT=dc=example,dc=org
+LDAP_ADMIN_USERNAME=admin
+LDAP_ADMIN_PASSWORD=adminpassword
+LDAP_TEST_USER=testuser
+LDAP_TEST_PASSWORD=testpass
+
+### Keycloak (auth_backend: OIDC) ###
+# admin console login at http://localhost:8081
+KC_ADMIN_USERNAME=admin
+KC_ADMIN_PASSWORD=admin
+# pre-provisioned by tests/keycloak/realm.json (imported on startup):
+# realm 'keepass', client 'keepass4web' with this secret, and a test user
+# 'testuser' / 'testpass'
+OIDC_CLIENT_ID=keepass4web
+OIDC_CLIENT_SECRET=insecure-example-client-secret

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ LDAP_TEST_USER=testuser
 LDAP_TEST_PASSWORD=testpass
 
 ### Keycloak (auth_backend: OIDC) ###
-# admin console login at http://localhost:8081
+# admin console login at http://localhost:8180
 KC_ADMIN_USERNAME=admin
 KC_ADMIN_PASSWORD=admin
 # pre-provisioned by tests/keycloak/realm.json (imported on startup):

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Packages
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
@@ -37,6 +43,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # gate on the bug-catching lint groups; style lints are not enforced yet
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious
+
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
       RUST_BACKTRACE: full
     steps:
       - uses: actions/checkout@v5
@@ -34,8 +33,6 @@ jobs:
   frontend-e2e:
     name: Frontend E2E Tests
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ public/fonts/*
 # data
 *.kdbx
 
+# local environment (copied from .env.example)
+.env
+
 # jetbrains
 .idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,12 +388,6 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -557,24 +551,13 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq 0.1.5",
-]
-
-[[package]]
-name = "blake2b_simd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
- "constant_time_eq 0.3.1",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -790,15 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
-name = "clippy"
-version = "0.0.302"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d911ee15579a3f50880d8c1d59ef6e79f9533127a3bd342462f5d584f5e8c294"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,12 +800,6 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -902,15 +870,6 @@ name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crypto-bigint"
@@ -1110,17 +1069,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1412,17 +1360,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -1430,7 +1367,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1911,7 +1848,7 @@ dependencies = [
  "getrandom 0.2.10",
  "hex-literal",
  "hmac 0.12.1",
- "rust-argon2 2.0.0",
+ "rust-argon2",
  "salsa20",
  "secstr",
  "serde",
@@ -1936,8 +1873,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "clap",
- "clippy",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
  "env_logger",
  "futures",
  "futures-util",
@@ -2145,7 +2081,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2397,7 +2333,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2607,28 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2 0.8.3",
 ]
 
 [[package]]
@@ -2767,25 +2686,13 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd 0.5.11",
- "constant_time_eq 0.1.5",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rust-argon2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e71971821b3ae0e769e4a4328dbcb517607b434db7697e9aba17203ec14e46a"
 dependencies = [
  "base64 0.21.7",
- "blake2b_simd 1.0.2",
- "constant_time_eq 0.3.1",
+ "blake2b_simd",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -3322,17 +3229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs",
- "winapi",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,12 +3520,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ regex = "1.10.2"
 mime = "0.3.17"
 aes-gcm = { version = "0.10.3", features = ["zeroize", "std"] }
 constant_time_eq = "0.3.1"
-linux-keyutils = { version = "0.2.4", features = ["std"] }
 url = { version = "2.5.0", features = ["serde"] }
 openidconnect = "3.4.0"
 async-trait = "0.1.77"
@@ -42,6 +41,9 @@ reqwest = { version = "0.11.27", features = ["rustls", "__tls", "rustls-tls", "s
 futures = "0.3.31"
 futures-util = { version = "0.3.30", default-features = false, features = ["io"] }
 htpasswd-verify = { git = "https://github.com/twistedfall/htpasswd-verify", rev = "ff14703083cbd639f7d05622b398926f3e718d61" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-keyutils = { version = "0.2.4", features = ["std"] }
 
 [dev-dependencies]
 mockito = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,4 @@ futures-util = { version = "0.3.30", default-features = false, features = ["io"]
 htpasswd-verify = { git = "https://github.com/twistedfall/htpasswd-verify", rev = "ff14703083cbd639f7d05622b398926f3e718d61" }
 
 [dev-dependencies]
-clippy = "0.0.302"
 mockito = "1.7.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,17 @@ RUN npm install
 RUN cp node_modules/bootstrap/fonts/* public/fonts/
 RUN npm run build
 
-COPY src src
-COPY Cargo.* ./
-
 RUN apk add --no-cache build-base
-ENV RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
-RUN cargo build --bins --release
+
+# build dependencies in their own layer, so source changes don't recompile them
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src \
+    && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
+
+COPY src src
+RUN touch src/main.rs && cargo build --bins --release
 
 
 FROM scratch
@@ -31,6 +36,9 @@ VOLUME /conf
 
 USER 1000:1000
 
-ENV RUST_BACKTRACE=1;
+ENV RUST_BACKTRACE=1
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD ["/keepass4web", "--config", "/conf/config.yml", "--health-check"]
 
 CMD [ "/keepass4web", "--config", "/conf/config.yml"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   - [CONFIGURATION](#configuration)
   - [DEPLOYMENT](#deployment)
     - [Container](#container)
+    - [Docker Compose — htpasswd (default)](#docker-compose--htpasswd-default)
+    - [Docker Compose — LDAP (OpenLDAP)](#docker-compose--ldap-openldap)
+    - [Docker Compose — OIDC (Keycloak)](#docker-compose--oidc-keycloak)
     - [Classic](#classic)
   - [BACKENDS](#backends)
     - [Authentication Backends](#authentication-backends)
@@ -72,7 +75,12 @@ The minified, bundled file will be written to public/scripts/bundle.js
 
 ## CONFIGURATION
 
-- See `config.yml`
+Copy `config.example.yml` to `config.yml` and edit as needed. The example file contains
+ready-to-use snippets for every supported backend, with values that match the bundled
+docker-compose test services so you can test any backend with minimal changes.
+
+The default `config.yml` uses htpasswd authentication. See `config.example.yml` for
+LDAP and OIDC examples and documentation of every option.
 
 ## DEPLOYMENT
 
@@ -129,35 +137,111 @@ Example podman:
 
 (master password: `test`)
 
+> **Docker Desktop on macOS / Windows:** the kernel keyring syscalls are blocked by default.
+> Set `use_keyring: false` in `config.yml` to use the in-memory key store instead.
 
-### Docker Compose
+### Docker Compose — htpasswd (default)
 
-For easier deployment, you can use Docker Compose file
+The bundled `docker-compose.yml` starts the app with local htpasswd authentication:
 
-Then, to start the container run:
+```bash
+# 1. Create a password file (bcrypt)
+htpasswd -cB .htpasswd <username>
 
-
-```
+# 2. Start the stack
 docker-compose up -d
-
 ```
 
-To stop the container:
+App is available at <http://localhost:8080> (KeePass master password: `test`).
 
-```
+To stop:
+
+```bash
 docker-compose down
 ```
 
+### Docker Compose — LDAP (OpenLDAP)
+
+The repo ships a pre-configured OpenLDAP test service. Enable it with these steps:
+
+```bash
+# 1. Copy example credentials (safe defaults for local testing)
+cp .env.example .env
+
+# 2. Uncomment the 'openldap' service block in docker-compose.yml
+
+# 3. Switch config.yml to LDAP — replace auth_backend and add the LDAP block:
+cat >> config.yml <<'EOF'
+
+auth_backend: 'LDAP'
+LDAP:
+  uri: 'ldap://openldap:1389'
+  scope: 'subtree'
+  base_dn: 'ou=users,dc=example,dc=org'
+  filter: '(objectClass=inetOrgPerson)'
+  login_attribute: 'uid'
+  bind: 'cn=admin,dc=example,dc=org'
+  password: 'adminpassword'
+EOF
+
+# 4. Start the stack
+docker-compose up -d
+```
+
+Log in with the test user defined in `.env` (`LDAP_TEST_USER` / `LDAP_TEST_PASSWORD`,
+defaults `testuser` / `testpass`).
+
+For a full LDAP config reference including Active Directory and per-user database
+attributes see `config.example.yml`.
+
+### Docker Compose — OIDC (Keycloak)
+
+The repo ships a Keycloak instance with a pre-imported realm (`keepass`) and a
+pre-configured client (`keepass4web`). Enable it with these steps:
+
+```bash
+# 1. Copy example credentials (safe defaults for local testing)
+cp .env.example .env
+
+# 2. Uncomment the 'keycloak' service block in docker-compose.yml
+
+# 3. Switch config.yml to OIDC — replace auth_backend and add the OIDC block:
+cat >> config.yml <<'EOF'
+
+auth_backend: 'OIDC'
+OIDC:
+  issuer: 'http://keycloak:8180/realms/keepass'
+  client_id: 'keepass4web'
+  client_secret: 'insecure-example-client-secret'
+  save_id_token: true
+  scopes:
+    - 'profile'
+
+# OIDC redirect flow requires lax cookie policy
+cookie_samesite: 'lax'
+EOF
+
+# 4. Start the stack (Keycloak takes ~30 s to start)
+docker-compose up -d
+```
+
+- App: <http://localhost:8080> — log in with `testuser` / `testpass`
+- Keycloak admin console: <http://localhost:8180> — credentials from `.env`
+  (`KC_ADMIN_USERNAME` / `KC_ADMIN_PASSWORD`, defaults `admin` / `admin`)
+
+For a full OIDC config reference see `config.example.yml`.
+
+> **Note:** if you run the app outside docker-compose, replace `keycloak` in the
+> issuer URL with `localhost`: `http://localhost:8180/realms/keepass`.
+
 ### Classic
 
-This requires rust installed, compile the binary:
+This requires rust installed. Compile and run the binary:
 
-    export RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
-    cargo build --bins --release --target-dir release
-
-Run the binary:
-
-    target/release/keepass4web-rs
+```bash
+cargo build --bins --release
+./target/release/keepass4web-rs
+```
 
 ## BACKENDS
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -98,16 +98,16 @@ htpasswd:
 # uncomment the 'keycloak:' block in docker-compose.yml)
 #
 # Pre-provisioned: client 'keepass4web', user testuser / testpass.
-# Admin console:   http://localhost:8081  (KC_ADMIN_USERNAME/PASSWORD from .env)
+# Admin console:   http://localhost:8180  (KC_ADMIN_USERNAME/PASSWORD from .env)
 #
 # To use: set auth_backend: 'OIDC', fill in your real values below.
 # Note: OIDC redirect requires cookie_samesite: 'lax' (see below).
 # ──────────────────────────────────────────────────────────────
 # OIDC:
 #     # Issuer URL (the OpenID Connect discovery endpoint is <issuer>/.well-known/openid-configuration)
-#     # docker-compose service:          http://keycloak:8080/realms/keepass
-#     # running the app outside compose: http://localhost:8081/realms/keepass
-#     issuer: 'http://keycloak:8080/realms/keepass'
+#     # docker-compose service and outside compose: http://keycloak:8180/realms/keepass
+#     # (Keycloak runs on port 8180; keepass app is on 8080)
+#     issuer: 'http://keycloak:8180/realms/keepass'
 #
 #     client_id: 'keepass4web'
 #     client_secret: 'insecure-example-client-secret'

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,175 @@
+##############################################################
+### config.example.yml — copy-and-edit reference            ###
+###                                                          ###
+### Values for LDAP and OIDC match the test services in     ###
+### docker-compose.yml / .env.example exactly.  Enable the  ###
+### matching service in docker-compose.yml, set             ###
+### auth_backend below, and the app will work immediately.  ###
+###                                                          ###
+### For production deployments replace every value that     ###
+### says "example", "test", or "insecure" with your own.    ###
+##############################################################
+
+# Where to get KeePass databases from.
+# Available: Filesystem, HTTP
+db_backend: 'Filesystem'
+
+# Authentication backend — pick ONE, configure its section below.
+# Available: None, htpasswd, LDAP, OIDC
+#
+#   None     — no authentication (single-user / trusted-network only)
+#   htpasswd — local password file (bcrypt); good for small teams
+#   LDAP     — OpenLDAP / Active Directory
+#   OIDC     — OpenID Connect (Keycloak, Authentik, Azure AD, …)
+#
+auth_backend: 'htpasswd'
+
+
+### Database backends ###
+
+# db_backend: Filesystem
+Filesystem:
+    db_location: './db.kdbx'
+    # optional key file — storing key files on the server is not recommended
+    # keyfile_location: './db.key'
+
+# db_backend: HTTP  (fetch database over HTTP/HTTPS)
+# HTTP:
+#     database_url: 'https://files.example.com/db.kdbx'
+#     # keyfile_url: 'https://files.example.com/db.key'
+#     # credentials:
+#     #   username: 'fileuser'
+#     #   password: 'filepassword'
+#     # bearer: 'token-here'
+
+
+### Authentication backends ###
+
+# auth_backend: htpasswd
+# Create .htpasswd with: htpasswd -cB .htpasswd <username>
+htpasswd:
+    path: '.htpasswd'
+
+
+# ──────────────────────────────────────────────────────────────
+# LDAP example — matches the docker-compose OpenLDAP test service
+# (bitnami/openldap, seeded via LDAP_TEST_USER / LDAP_TEST_PASSWORD
+# from .env.example; uncomment the 'openldap:' block in docker-compose.yml)
+#
+# To use: set auth_backend: 'LDAP', fill in your real values below.
+# ──────────────────────────────────────────────────────────────
+# LDAP:
+#     # LDAP server URI
+#     # docker-compose service: ldap://openldap:1389
+#     # running the app outside compose: ldap://127.0.0.1:1389
+#     uri: 'ldap://openldap:1389'
+#
+#     # search scope: subtree (all sub-nodes), one (immediate children), base
+#     scope: 'subtree'
+#
+#     # search base distinguished name
+#     base_dn: 'ou=users,dc=example,dc=org'
+#
+#     # extra filter combined with the login attribute match:
+#     #   (&(<login_attribute>=<username>)<filter>)
+#     # leave empty to match on the login attribute only
+#     filter: '(objectClass=inetOrgPerson)'
+#
+#     # attribute used for login (must be unique per user)
+#     # Active Directory:  sAMAccountName  or  userPrincipalName
+#     # OpenLDAP / 389 DS: uid
+#     login_attribute: 'uid'
+#
+#     # DN and password for the read-only bind used to search the directory
+#     # (leave empty for anonymous bind if your LDAP allows it)
+#     bind: 'cn=admin,dc=example,dc=org'
+#     password: 'adminpassword'
+#
+#     # optional: per-user KeePass database / key file locations
+#     # stored as LDAP attributes on the user object
+#     # leave commented out to use the static Filesystem/HTTP location above
+#     # database_attribute: 'keePass'
+#     # keyfile_attribute:  'keePassKeyFile'
+
+
+# ──────────────────────────────────────────────────────────────
+# OIDC example — matches the docker-compose Keycloak test service
+# (realm 'keepass' auto-imported from tests/keycloak/realm.json;
+# uncomment the 'keycloak:' block in docker-compose.yml)
+#
+# Pre-provisioned: client 'keepass4web', user testuser / testpass.
+# Admin console:   http://localhost:8081  (KC_ADMIN_USERNAME/PASSWORD from .env)
+#
+# To use: set auth_backend: 'OIDC', fill in your real values below.
+# Note: OIDC redirect requires cookie_samesite: 'lax' (see below).
+# ──────────────────────────────────────────────────────────────
+# OIDC:
+#     # Issuer URL (the OpenID Connect discovery endpoint is <issuer>/.well-known/openid-configuration)
+#     # docker-compose service:          http://keycloak:8080/realms/keepass
+#     # running the app outside compose: http://localhost:8081/realms/keepass
+#     issuer: 'http://keycloak:8080/realms/keepass'
+#
+#     client_id: 'keepass4web'
+#     client_secret: 'insecure-example-client-secret'
+#
+#     # save the ID token in the session for cleaner single-logout
+#     # disable if the token is too large for the session cookie
+#     save_id_token: true
+#
+#     scopes:
+#       - 'profile'
+#       # add the 'keepass' scope if your IdP is configured to return
+#       # database_location / keyfile_location claims per user
+#       # - 'keepass'
+
+
+### General settings ###
+
+# Time before the database is automatically closed (user idle timeout).
+# User must re-enter the database master password after this.
+db_session_timeout: '10 minutes'
+
+# How often to re-check whether the auth backend has changed
+# (used to refresh the login page for idling users).
+auth_check_interval: '1 hour 5 minutes'
+
+search:
+  # Entry fields included in keyword search
+  fields:
+    - title
+    - username
+    - tags
+    - notes
+    - url
+  # also search custom fields and attachment file names
+  extra_fields: true
+  # allow regular expressions in search terms
+  allow_regex: false
+
+# Secret key for signing session cookies.
+# Must be at least 64 bytes, from a cryptographically secure source.
+# Generated on the fly when omitted — sessions do not survive restarts.
+# Set a static value to keep sessions across restarts.
+# session_secret_key: ''
+
+# How long a session cookie lives in the browser.
+session_lifetime: '1 hour'
+
+# SameSite policy for the session cookie: strict / lax / none
+# Use 'lax' when auth_backend is OIDC (redirect flow requires it).
+cookie_samesite: 'strict'
+# cookie_samesite: 'lax'   # ← uncomment when using OIDC
+
+# Trust Forwarded / X-Forwarded-For headers for the client IP.
+# Used by login rate limiting.  Only enable when running behind a
+# reverse proxy you control; these headers are client-spoofable otherwise.
+trust_proxy_headers: false
+
+# Use the Linux kernel keyring for session key storage (Linux only).
+# Set to false if your container runtime blocks keyctl/add_key/request_key
+# (e.g. Docker Desktop on macOS without a custom seccomp profile).
+# Ignored on non-Linux platforms, which always use the in-memory store.
+use_keyring: true
+
+listen: '::'
+port:   8080

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,9 @@ LDAP:
     uri:    'ldap://127.0.0.1:389'
     scope:  'subtree'
     base_dn: 'OU=People,DC=example,DC=org'
+    # additional filter, automatically combined with the login attribute match:
+    # (&(<login_attribute>=<username>)<filter>)
+    # no placeholder substitution takes place, leave empty to match on the login attribute only
     filter: '(&(objectClass=inetOrgPerson)(memberOf=CN=keepass,OU=groups,DC=example,DC=org))'
 
     # (unique) ldap attribute for user login

--- a/config.yml
+++ b/config.yml
@@ -105,5 +105,10 @@ session_lifetime: '1 hour'
 # Redirecting backends might require lax here
 cookie_samesite: 'strict'
 
+# Whether to trust Forwarded/X-Forwarded-For headers for the client ip
+# (used by login rate limiting). Only enable when running behind a
+# reverse proxy that sets these headers, they are spoofable otherwise.
+trust_proxy_headers: false
+
 listen:  '::'
 port:    8080

--- a/config.yml
+++ b/config.yml
@@ -110,5 +110,14 @@ cookie_samesite: 'strict'
 # reverse proxy that sets these headers, they are spoofable otherwise.
 trust_proxy_headers: false
 
+# Whether to use the Linux kernel keyring for session key storage.
+# Ignored on non-Linux platforms (always falls back to in-memory).
+# Set to false if your container runtime blocks the keyctl/add_key/request_key
+# syscalls — for example when running the Docker image on macOS with Docker
+# Desktop and no custom seccomp profile. The in-memory store is slightly
+# weaker (keys live in process memory rather than the kernel) but fully
+# functional for single-instance deployments.
+use_keyring: true
+
 listen:  '::'
 port:    8080

--- a/config.yml
+++ b/config.yml
@@ -1,123 +1,85 @@
 ##################################
 ### KeePass4Web related config ###
 ##################################
+#
+# This is the default configuration using local htpasswd authentication.
+# For LDAP or OIDC examples with pre-filled test values see config.example.yml.
+#
 
-# where to get keepass database from
-# available: Filesystem, HTTP
+# Where to get KeePass databases from.
+# Available: Filesystem, HTTP
 db_backend: 'Filesystem'
 
-# backend to authenticate users before anything else
-# available: None, LDAP, OIDC, htpasswd
-# None is only useful in single-user environments
-auth_backend: 'None'
+# Authentication backend.
+# Available: None, htpasswd, LDAP, OIDC
+# See config.example.yml for LDAP and OIDC configuration examples.
+auth_backend: 'htpasswd'
+
 
 ### Database backends ###
 
-# filesystem specific configuration, db_backend = 'Filesystem'
+# db_backend: Filesystem
 Filesystem:
     db_location: './db.kdbx'
-    # optional, storing key files on the filesystem is not recommended
+    # optional key file — storing key files on the server is not recommended
     # keyfile_location: './db.key'
 
-# http specific configuration, db_backend = 'HTTP'
-HTTP:
-    # database_url: ''
-    # keyfile_url: ''
-    # credentials:
-    #   username: ''
-    #   password: ''
-    # bearer: ''
+# db_backend: HTTP
+# HTTP:
+#     database_url: ''
+#     # keyfile_url: ''
+#     # credentials:
+#     #   username: ''
+#     #   password: ''
+#     # bearer: ''
+
 
 ### Authentication backends ###
 
-# ldap specific configuration, auth_backend = 'LDAP'
-LDAP:
-    uri:    'ldap://127.0.0.1:389'
-    scope:  'subtree'
-    base_dn: 'OU=People,DC=example,DC=org'
-    # additional filter, automatically combined with the login attribute match:
-    # (&(<login_attribute>=<username>)<filter>)
-    # no placeholder substitution takes place, leave empty to match on the login attribute only
-    filter: '(&(objectClass=inetOrgPerson)(memberOf=CN=keepass,OU=groups,DC=example,DC=org))'
-
-    # (unique) ldap attribute for user login
-    # Active Directory: sAMAccountName or userPrincipalName
-    # openLDAP/389 Directory Server/etc: uid
-    login_attribute: 'uid'
-
-    # ldap bind DN and password, leave empty for anonymous bind
-    bind:     'CN=ldap-read,OU=Special Users,DC=example,DC=org'
-    password: ''
-
-    # ldap attribute containing the keepass database and/or keyfile location for the authed user
-    # leave commented out to use static db/keyfile location from db backend
-    # database_attribute: 'keePass'
-    # keyfile_attribute:  'keePassKeyFile'
-
-# open id connect specific configuration, auth_backend = 'OIDC'
-OIDC:
-    # url to the issuer (discovery url)
-    # issuer: ''
-    client_id: ''
-    client_secret: ''
-    # required for logout without confirmation
-    # the token is pretty big and might not fit into a session cookie
-    # disable if issues arise
-    save_id_token: true
-    scopes:
-      - 'profile'
-      # scope containing the keepass_location and/or keyfile_location claims for the authed user
-      # leave commented out to use static db/keyfile location from db backend
-      # - 'keepass'
-
-# htpasswd specific configuration, auth_backend = 'htpasswd'
+# auth_backend: htpasswd
+# Create the password file with: htpasswd -cB .htpasswd <username>
 htpasswd:
     path: '.htpasswd'
 
-# time till database gets closed (user idle time)
-# user will have to reenter database password/keyfile
+
+### General settings ###
+
+# Time before the database is automatically closed (user idle timeout).
 db_session_timeout: '10 minutes'
-# interval to watch for user auth_backend changes (to present proper login page, even when user is idling)
+
+# How often to re-check whether the auth backend has changed.
 auth_check_interval: '1 hour 5 minutes'
 
 search:
-  # fields to search for matching entries
   fields:
     - title
     - username
     - tags
     - notes
     - url
-  # whether to search in user supplied fields and file names
   extra_fields: true
-  # whether regexes in the search pattern are interpreted
   allow_regex: false
 
-
-# Secret key used for session cookies
-# Must be at least 64 bytes long, obtained from a cryptographically secure source.
-# Will be generated on the fly if not specified.
-# Set a static key for sessions to survive server restarts.
+# Secret key for signing session cookies (at least 64 bytes).
+# Generated on the fly when omitted — sessions don't survive restarts.
+# Set a static value to keep sessions across restarts.
 # session_secret_key: ''
-# Cookie session lifetime
+
+# How long a session cookie lives in the browser.
 session_lifetime: '1 hour'
-# Cookie same site setting: strict/lax/none
-# Redirecting backends might require lax here
+
+# SameSite policy for the session cookie: strict / lax / none
+# Use 'lax' when auth_backend is OIDC (redirect flow requires it).
 cookie_samesite: 'strict'
 
-# Whether to trust Forwarded/X-Forwarded-For headers for the client ip
-# (used by login rate limiting). Only enable when running behind a
-# reverse proxy that sets these headers, they are spoofable otherwise.
+# Trust Forwarded / X-Forwarded-For headers for the client IP.
+# Only enable when running behind a reverse proxy you control.
 trust_proxy_headers: false
 
-# Whether to use the Linux kernel keyring for session key storage.
-# Ignored on non-Linux platforms (always falls back to in-memory).
-# Set to false if your container runtime blocks the keyctl/add_key/request_key
-# syscalls — for example when running the Docker image on macOS with Docker
-# Desktop and no custom seccomp profile. The in-memory store is slightly
-# weaker (keys live in process memory rather than the kernel) but fully
-# functional for single-instance deployments.
+# Use the Linux kernel keyring for session key storage (Linux only).
+# Set to false if your container runtime blocks keyctl/add_key/request_key
+# (e.g. Docker Desktop on macOS without a custom seccomp profile).
 use_keyring: true
 
-listen:  '::'
-port:    8080
+listen: '::'
+port:   8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,63 @@ services:
       - ./tests/test.kdbx:/db.kdbx
     security_opt:
       - seccomp=seccomp/keyring.json
+
+  ### Optional auth backends for testing ###
+  #
+  # The services below are disabled by default. To enable one, remove the
+  # leading '#' from its block (and from the matching volumes entry at the
+  # bottom, where present), then run: docker compose up -d
+  #
+  # --- OpenLDAP (auth_backend: LDAP) ---
+  #
+  # Seeded with user 'testuser' / password 'testpass'.
+  # Matching config.yml settings:
+  #
+  #   auth_backend: 'LDAP'
+  #   LDAP:
+  #     uri: 'ldap://openldap:1389'        # 'ldap://127.0.0.1:1389' when running the app outside compose
+  #     scope: 'subtree'
+  #     base_dn: 'ou=users,dc=example,dc=org'
+  #     filter: '(objectClass=inetOrgPerson)'
+  #     login_attribute: 'uid'
+  #     bind: 'cn=admin,dc=example,dc=org'
+  #     password: 'adminpassword'
+  #
+  #openldap:
+  #  image: docker.io/bitnamilegacy/openldap:2.6
+  #  ports:
+  #    - "1389:1389"
+  #  environment:
+  #    - LDAP_ROOT=dc=example,dc=org
+  #    - LDAP_ADMIN_USERNAME=admin
+  #    - LDAP_ADMIN_PASSWORD=adminpassword
+  #    - LDAP_USERS=testuser
+  #    - LDAP_PASSWORDS=testpass
+
+  # --- Keycloak (auth_backend: OIDC) ---
+  #
+  # Admin console: http://localhost:8081 (admin / admin).
+  # One-time setup: create a realm (e.g. 'keepass'), add a client with
+  # 'Client authentication' enabled, set its valid redirect URI to
+  # http://localhost:8080/callback_user_auth, create a test user with a
+  # password, then copy the client id/secret into config.yml:
+  #
+  #   auth_backend: 'OIDC'
+  #   OIDC:
+  #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
+  #     client_id: 'keepass4web'
+  #     client_secret: '<client secret from Keycloak>'
+  #     save_id_token: true
+  #     scopes:
+  #       - 'profile'
+  #
+  # Note: redirecting auth backends may require cookie_samesite: 'lax'.
+  #
+  #keycloak:
+  #  image: quay.io/keycloak/keycloak:26.0
+  #  command: start-dev
+  #  ports:
+  #    - "8081:8080"
+  #  environment:
+  #    - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,12 @@ services:
   # The realm 'keepass' is imported automatically from tests/keycloak/realm.json:
   # confidential client 'keepass4web' (secret in .env.example) with the redirect
   # URI http://localhost:8080/callback_user_auth, and user 'testuser' / 'testpass'.
-  # Admin console: http://localhost:8081 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
+  # Admin console: http://localhost:8180 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
   # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'OIDC'
   #   OIDC:
-  #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
+  #     issuer: 'http://keycloak:8180/realms/keepass'   # 'http://localhost:8180/realms/keepass' outside compose
   #     client_id: 'keepass4web'
   #     client_secret: 'insecure-example-client-secret'
   #     save_id_token: true
@@ -65,9 +65,9 @@ services:
   #
   #keycloak:
   #  image: quay.io/keycloak/keycloak:26.0
-  #  command: start-dev --import-realm
+  #  command: start-dev --http-port=8180 --import-realm
   #  ports:
-  #    - "8081:8080"
+  #    - "8180:8180"
   #  volumes:
   #    - ./tests/keycloak:/opt/keycloak/data/import:ro
   #  environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,16 @@ services:
 
   ### Optional auth backends for testing ###
   #
-  # The services below are disabled by default. To enable one, remove the
-  # leading '#' from its block (and from the matching volumes entry at the
-  # bottom, where present), then run: docker compose up -d
+  # The services below are disabled by default. To enable one:
+  #   1. cp .env.example .env   (example credentials, adjust if you like)
+  #   2. remove the leading '#' from the service block you need
+  #      (openldap for auth_backend: LDAP, keycloak for auth_backend: OIDC)
+  #   3. update config.yml as shown below, then: docker compose up -d
   #
   # --- OpenLDAP (auth_backend: LDAP) ---
   #
-  # Seeded with user 'testuser' / password 'testpass'.
-  # Matching config.yml settings:
+  # Seeded with the LDAP_TEST_USER / LDAP_TEST_PASSWORD user from .env.
+  # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'LDAP'
   #   LDAP:
@@ -36,25 +38,25 @@ services:
   #  ports:
   #    - "1389:1389"
   #  environment:
-  #    - LDAP_ROOT=dc=example,dc=org
-  #    - LDAP_ADMIN_USERNAME=admin
-  #    - LDAP_ADMIN_PASSWORD=adminpassword
-  #    - LDAP_USERS=testuser
-  #    - LDAP_PASSWORDS=testpass
+  #    - LDAP_ROOT=${LDAP_ROOT}
+  #    - LDAP_ADMIN_USERNAME=${LDAP_ADMIN_USERNAME}
+  #    - LDAP_ADMIN_PASSWORD=${LDAP_ADMIN_PASSWORD}
+  #    - LDAP_USERS=${LDAP_TEST_USER}
+  #    - LDAP_PASSWORDS=${LDAP_TEST_PASSWORD}
 
   # --- Keycloak (auth_backend: OIDC) ---
   #
-  # Admin console: http://localhost:8081 (admin / admin).
-  # One-time setup: create a realm (e.g. 'keepass'), add a client with
-  # 'Client authentication' enabled, set its valid redirect URI to
-  # http://localhost:8080/callback_user_auth, create a test user with a
-  # password, then copy the client id/secret into config.yml:
+  # The realm 'keepass' is imported automatically from tests/keycloak/realm.json:
+  # confidential client 'keepass4web' (secret in .env.example) with the redirect
+  # URI http://localhost:8080/callback_user_auth, and user 'testuser' / 'testpass'.
+  # Admin console: http://localhost:8081 (KC_ADMIN_USERNAME / KC_ADMIN_PASSWORD from .env).
+  # Matching config.yml settings (with the .env.example defaults):
   #
   #   auth_backend: 'OIDC'
   #   OIDC:
   #     issuer: 'http://keycloak:8080/realms/keepass'   # 'http://localhost:8081/realms/keepass' outside compose
   #     client_id: 'keepass4web'
-  #     client_secret: '<client secret from Keycloak>'
+  #     client_secret: 'insecure-example-client-secret'
   #     save_id_token: true
   #     scopes:
   #       - 'profile'
@@ -63,9 +65,11 @@ services:
   #
   #keycloak:
   #  image: quay.io/keycloak/keycloak:26.0
-  #  command: start-dev
+  #  command: start-dev --import-realm
   #  ports:
   #    - "8081:8080"
+  #  volumes:
+  #    - ./tests/keycloak:/opt/keycloak/data/import:ro
   #  environment:
-  #    - KC_BOOTSTRAP_ADMIN_USERNAME=admin
-  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+  #    - KC_BOOTSTRAP_ADMIN_USERNAME=${KC_ADMIN_USERNAME}
+  #    - KC_BOOTSTRAP_ADMIN_PASSWORD=${KC_ADMIN_PASSWORD}

--- a/js/scripts/DBLogin.js
+++ b/js/scripts/DBLogin.js
@@ -4,40 +4,83 @@ import NavBar from './NavBar'
 import Alert from './Alert'
 import Info from './Info'
 import withNavigateHook from './nagivateHook'
+import { IconDatabase, IconKey, IconUpload } from './Icons'
 
 class DBLogin extends LoginForm {
     constructor() {
         super()
         this.url = 'db_login'
         this.handleFile = this.handleFile.bind(this)
+        this.state = { ...this.state, fileName: null }
     }
 
     handleFile(event) {
         const file = event.target.files[0]
+        if (!file) return
+        this.setState({ fileName: file.name })
         const reader = new FileReader()
-
         const me = this
         reader.onload = function () {
-            // race condition!?
             me.refs.key.value = reader.result.split(',')[1]
         }
         reader.readAsDataURL(file)
     }
 
     render() {
+        const { fileName } = this.state
         return (
             <div>
                 <NavBar/>
                 <div className="container">
                     <div className={this.classes()}>
                         <form className="kp-login-inner" onSubmit={this.handleLogin}>
-                            <h4>KeePass Login</h4>
-                            <input className="form-control user" type="password" ref="password"
-                                   placeholder="Master Password" autoFocus="autoFocus"/>
-                            <input className="input-group btn" type="file" accept="*/*" ref="keyfile"
-                                   placeholder="Key file" onChange={this.handleFile}/>
+                            <div className="kp-login-icon">
+                                <IconDatabase size={28}/>
+                            </div>
+                            <h4>Open Vault</h4>
+                            <p className="kp-login-sub">Enter your credentials to unlock</p>
+
+                            <div className="kp-login-field">
+                                <label htmlFor="kp-master-pw">
+                                    <IconKey size={13}/>
+                                    Master Password
+                                </label>
+                                <input
+                                    id="kp-master-pw"
+                                    className="kp-input"
+                                    type="password"
+                                    ref="password"
+                                    placeholder="Enter master password"
+                                    autoFocus
+                                />
+                            </div>
+
+                            <div className="kp-login-field">
+                                <label htmlFor="kp-keyfile-input">
+                                    <IconUpload size={13}/>
+                                    Key File
+                                    <span className="kp-login-optional">optional</span>
+                                </label>
+                                <input
+                                    id="kp-keyfile-input"
+                                    type="file"
+                                    accept="*/*"
+                                    ref="keyfile"
+                                    onChange={this.handleFile}
+                                    style={{ display: 'none' }}
+                                />
+                                <label htmlFor="kp-keyfile-input" className={`kp-file-label${fileName ? ' has-file' : ''}`}>
+                                    <IconUpload size={13}/>
+                                    {fileName || 'Choose key file…'}
+                                </label>
+                            </div>
+
                             <input id="key" ref="key" type="hidden"/>
-                            <button className="btn btn-block btn-lg btn-success" type="submit">Open</button>
+
+                            <button className="kp-btn kp-btn-primary kp-btn-open" type="submit">
+                                Open Vault
+                            </button>
+
                             <Alert error={this.state.error}/>
                             <Info info={this.props.location.state && this.props.location.state.info}/>
                         </form>

--- a/js/scripts/EntryForm.js
+++ b/js/scripts/EntryForm.js
@@ -1,0 +1,284 @@
+import React from 'react'
+import { IconEye, IconEyeOff, IconRefresh, IconSave } from './Icons'
+
+const ICON_COUNT = 69  // KeePass standard icons: 0–68
+
+function generatePassword(length = 20) {
+    const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?'
+    const arr = new Uint8Array(length)
+    window.crypto.getRandomValues(arr)
+    return Array.from(arr).map(b => charset[b % charset.length]).join('')
+}
+
+function iconSrc(id) {
+    return `img/icons/${id}.png`
+}
+
+class EntryForm extends React.Component {
+    constructor(props) {
+        super(props)
+        const e = props.entry || {}
+        this.state = {
+            form: {
+                title:    e.title    || '',
+                username: e.username || '',
+                password: '',
+                url:      e.url      || '',
+                notes:    '',
+                icon:     e.icon     != null ? e.icon : null,
+            },
+            saving:       false,
+            showPassword: false,
+            pickerOpen:   false,
+        }
+        this._closePickerOutside = this._closePickerOutside.bind(this)
+    }
+
+    componentDidUpdate(prev) {
+        if (prev.entry !== this.props.entry || prev.mode !== this.props.mode) {
+            const e = this.props.entry || {}
+            this.setState({
+                form: {
+                    title:    e.title    || '',
+                    username: e.username || '',
+                    password: '',
+                    url:      e.url      || '',
+                    notes:    '',
+                    icon:     e.icon     != null ? e.icon : null,
+                },
+                saving: false,
+                showPassword: false,
+                pickerOpen: false,
+            })
+        }
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this._closePickerOutside)
+    }
+
+    _closePickerOutside(e) {
+        if (this._pickerRef && !this._pickerRef.contains(e.target)) {
+            this.closePicker()
+        }
+    }
+
+    openPicker() {
+        this.setState({ pickerOpen: true })
+        document.addEventListener('mousedown', this._closePickerOutside)
+    }
+
+    closePicker() {
+        this.setState({ pickerOpen: false })
+        document.removeEventListener('mousedown', this._closePickerOutside)
+    }
+
+    selectIcon(id) {
+        this.setState(prev => ({ form: { ...prev.form, icon: id }, pickerOpen: false }))
+        document.removeEventListener('mousedown', this._closePickerOutside)
+    }
+
+    set(field, e) {
+        const val = e.target.value
+        this.setState(prev => ({ form: { ...prev.form, [field]: val } }))
+    }
+
+    genPassword() {
+        this.setState(prev => ({
+            form: { ...prev.form, password: generatePassword() },
+            showPassword: true,
+        }))
+    }
+
+    submit(e) {
+        e.preventDefault()
+        const { mode, entry, group } = this.props
+        const { form } = this.state
+        if (!group && mode === 'new') return
+
+        this.setState({ saving: true })
+
+        const payload = { ...form }
+        if (payload.icon === null) delete payload.icon
+
+        if (mode === 'new') {
+            KeePass4Web.fetch('entry', {
+                method: 'POST',
+                data: { group_id: group.id, ...payload },
+                success: (data) => {
+                    this.setState({ saving: false })
+                    if (this.props.onSaved) this.props.onSaved(data && data.data && data.data.id)
+                },
+                error: (err) => {
+                    this.setState({ saving: false })
+                    KeePass4Web.error.call(this, err)
+                },
+            })
+        } else {
+            KeePass4Web.fetch('entry', {
+                method: 'PUT',
+                data: { id: entry.id, ...payload },
+                success: () => {
+                    this.setState({ saving: false })
+                    if (this.props.onSaved) this.props.onSaved(entry.id)
+                },
+                error: (err) => {
+                    this.setState({ saving: false })
+                    KeePass4Web.error.call(this, err)
+                },
+            })
+        }
+    }
+
+    render() {
+        const { mode, entry, group, onCancel } = this.props
+        const { form, saving, showPassword, pickerOpen } = this.state
+        const isNew = mode === 'new'
+
+        const groupName  = group ? group.title : ''
+        const entryName  = isNew ? 'New Entry' : (entry && entry.title) || 'Entry'
+        const selectedIcon = form.icon != null ? form.icon : 0
+
+        // icon picker grid
+        const iconGrid = []
+        for (let i = 0; i < ICON_COUNT; i++) {
+            iconGrid.push(
+                <div
+                    key={i}
+                    className={`kp-icon-grid-item${form.icon === i ? ' selected' : ''}`}
+                    title={`Icon ${i}`}
+                    onClick={() => this.selectIcon(i)}
+                >
+                    <img src={iconSrc(i)} alt={`icon ${i}`}/>
+                </div>
+            )
+        }
+
+        return (
+            <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                <div className="kp-detail-header">
+                    <h3>{isNew ? 'New Entry' : 'Edit Entry'}</h3>
+                </div>
+
+                <div className="kp-detail-entry-meta">
+                    <div className="kp-detail-icon" style={{ background: 'none', border: '1.5px solid var(--kp-border)' }}>
+                        <img src={iconSrc(selectedIcon)} style={{ width: 24, height: 24, objectFit: 'contain' }} alt=""/>
+                    </div>
+                    <div className="kp-detail-icon-info">
+                        <h4>{entryName}</h4>
+                        <p>{groupName}</p>
+                    </div>
+                    {!isNew && <span className="kp-detail-modified">Editing</span>}
+                </div>
+
+                <form className="kp-form" onSubmit={this.submit.bind(this)}>
+
+                    {/* Icon + Title row */}
+                    <div className="kp-form-icon-row">
+                        <div
+                            className="kp-icon-picker-wrap"
+                            ref={r => (this._pickerRef = r)}
+                        >
+                            <button
+                                type="button"
+                                className="kp-icon-trigger"
+                                title="Change icon"
+                                onClick={() => pickerOpen ? this.closePicker() : this.openPicker()}
+                            >
+                                <img src={iconSrc(selectedIcon)} alt="entry icon"/>
+                            </button>
+
+                            {pickerOpen && (
+                                <div className="kp-icon-picker">
+                                    <div className="kp-icon-picker-label">Choose icon</div>
+                                    <div className="kp-icon-grid">{iconGrid}</div>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="kp-field" style={{ flex: 1 }}>
+                            <label htmlFor="kp-f-title">Title</label>
+                            <input
+                                className="kp-input" id="kp-f-title"
+                                type="text" placeholder="Entry title" required autoFocus
+                                value={form.title}
+                                onChange={this.set.bind(this, 'title')}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="kp-field">
+                        <label htmlFor="kp-f-username">Username</label>
+                        <input
+                            className="kp-input" id="kp-f-username"
+                            type="text" placeholder="Username"
+                            value={form.username}
+                            onChange={this.set.bind(this, 'username')}
+                        />
+                    </div>
+
+                    <div className="kp-field">
+                        <label htmlFor="kp-f-password">Password</label>
+                        <div className="kp-input-group">
+                            <input
+                                className="kp-input" id="kp-f-password"
+                                type={showPassword ? 'text' : 'password'}
+                                placeholder={isNew ? 'Password' : 'Leave blank to keep existing'}
+                                value={form.password}
+                                onChange={this.set.bind(this, 'password')}
+                            />
+                            <div className="kp-input-group-btns">
+                                <button
+                                    type="button" className="kp-btn-outline kp-btn"
+                                    title={showPassword ? 'Hide' : 'Show'}
+                                    onClick={() => this.setState(p => ({ showPassword: !p.showPassword }))}
+                                >
+                                    {showPassword ? <IconEyeOff size={14}/> : <IconEye size={14}/>}
+                                </button>
+                                <button
+                                    type="button" className="kp-btn-outline kp-btn"
+                                    title="Generate random password"
+                                    onClick={this.genPassword.bind(this)}
+                                >
+                                    <IconRefresh size={14}/>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="kp-field">
+                        <label htmlFor="kp-f-url">URL</label>
+                        <input
+                            className="kp-input" id="kp-f-url"
+                            type="text" placeholder="https://…"
+                            value={form.url}
+                            onChange={this.set.bind(this, 'url')}
+                        />
+                    </div>
+
+                    <div className="kp-field">
+                        <label htmlFor="kp-f-notes">Notes</label>
+                        <textarea
+                            className="kp-input" id="kp-f-notes"
+                            placeholder="Optional notes…"
+                            value={form.notes}
+                            onChange={this.set.bind(this, 'notes')}
+                        />
+                    </div>
+
+                    <div className="kp-form-actions">
+                        <button type="button" className="kp-btn kp-btn-outline" onClick={onCancel}>
+                            Cancel
+                        </button>
+                        <button type="submit" className="kp-btn kp-btn-primary" disabled={saving}>
+                            <IconSave size={13}/>
+                            {saving ? 'Saving…' : 'Save Entry'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        )
+    }
+}
+
+export default EntryForm

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -12,21 +12,31 @@ function generatePassword(length = 20) {
     return Array.from(arr).map(b => charset[b % charset.length]).join('')
 }
 
+const EMPTY_FORM = { title: '', username: '', password: '', url: '', notes: '' }
+
 class GroupViewer extends React.Component {
     constructor(props) {
         super(props)
         this.state = {
+            // new entry form
             showForm: false,
-            form: { title: '', username: '', password: '', url: '', notes: '' },
+            form: { ...EMPTY_FORM },
             saving: false,
             showPassword: false,
+            // edit entry
+            editEntry: null,
+            editForm: { ...EMPTY_FORM },
+            editSaving: false,
+            editShowPassword: false,
+            // rename group
+            editingTitle: false,
+            titleDraft: '',
+            titleSaving: false,
+            // new group
+            showGroupForm: false,
+            newGroupName: '',
+            groupSaving: false,
         }
-        this.onNewEntry = this.onNewEntry.bind(this)
-        this.onFormChange = this.onFormChange.bind(this)
-        this.onSubmit = this.onSubmit.bind(this)
-        this.onCancel = this.onCancel.bind(this)
-        this.onGeneratePassword = this.onGeneratePassword.bind(this)
-        this.toggleShowPassword = this.toggleShowPassword.bind(this)
     }
 
     getIcon(element) {
@@ -36,8 +46,10 @@ class GroupViewer extends React.Component {
             return <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(element.icon) + '.png'}/>
     }
 
+    // ── new entry ────────────────────────────────────────────────────────────
+
     onNewEntry() {
-        this.setState({ showForm: true, showPassword: false, form: { title: '', username: '', password: '', url: '', notes: '' } })
+        this.setState({ showForm: true, showPassword: false, form: { ...EMPTY_FORM }, editEntry: null })
     }
 
     onCancel() {
@@ -49,25 +61,16 @@ class GroupViewer extends React.Component {
     }
 
     onGeneratePassword() {
-        const pw = generatePassword()
-        this.setState(prev => ({ form: { ...prev.form, password: pw }, showPassword: true }))
-    }
-
-    toggleShowPassword() {
-        this.setState(prev => ({ showPassword: !prev.showPassword }))
+        this.setState(prev => ({ form: { ...prev.form, password: generatePassword() }, showPassword: true }))
     }
 
     onSubmit(e) {
         e.preventDefault()
         if (!this.props.group) return
         this.setState({ saving: true })
-
         KeePass4Web.fetch('entry', {
             method: 'POST',
-            data: {
-                group_id: this.props.group.id,
-                ...this.state.form,
-            },
+            data: { group_id: this.props.group.id, ...this.state.form },
             success: (data) => {
                 this.setState({ showForm: false, saving: false })
                 if (this.props.onEntryCreated) this.props.onEntryCreated(data && data.id)
@@ -79,119 +82,311 @@ class GroupViewer extends React.Component {
         })
     }
 
-    render() {
-        const classes = Classnames({
-            'panel': true,
-            'panel-default': true,
-            'loading-mask': this.props.mask,
+    // ── edit entry ───────────────────────────────────────────────────────────
+
+    onEditEntry(entry, ev) {
+        ev.stopPropagation()
+        this.setState({
+            editEntry: entry,
+            editForm: { title: entry.title || '', username: entry.username || '', password: '', url: entry.url || '', notes: '' },
+            editShowPassword: false,
+            showForm: false,
         })
+    }
+
+    onEditFormChange(field, e) {
+        this.setState(prev => ({ editForm: { ...prev.editForm, [field]: e.target.value } }))
+    }
+
+    onEditGeneratePassword() {
+        this.setState(prev => ({ editForm: { ...prev.editForm, password: generatePassword() }, editShowPassword: true }))
+    }
+
+    onEditSubmit(e) {
+        e.preventDefault()
+        const { editEntry, editForm } = this.state
+        this.setState({ editSaving: true })
+        KeePass4Web.fetch('entry', {
+            method: 'PUT',
+            data: { id: editEntry.id, ...editForm },
+            success: () => {
+                this.setState({ editEntry: null, editSaving: false })
+                if (this.props.onEntryCreated) this.props.onEntryCreated()
+            },
+            error: (err) => {
+                this.setState({ editSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── create group ─────────────────────────────────────────────────────────
+
+    onNewGroup() {
+        this.setState({ showGroupForm: true, newGroupName: '', showForm: false, editEntry: null })
+    }
+
+    onGroupFormSubmit(e) {
+        e.preventDefault()
+        if (!this.props.group || !this.state.newGroupName.trim()) return
+        this.setState({ groupSaving: true })
+        KeePass4Web.fetch('group', {
+            method: 'POST',
+            data: { parent_id: this.props.group.id, title: this.state.newGroupName.trim() },
+            success: () => {
+                this.setState({ showGroupForm: false, newGroupName: '', groupSaving: false })
+                if (this.props.onGroupCreated) this.props.onGroupCreated()
+            },
+            error: (err) => {
+                this.setState({ groupSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── rename group ─────────────────────────────────────────────────────────
+
+    onRenameStart() {
+        this.setState({ editingTitle: true, titleDraft: this.props.group.title })
+    }
+
+    onRenameSave(e) {
+        e.preventDefault()
+        const { titleDraft } = this.state
+        if (!titleDraft.trim()) return
+        this.setState({ titleSaving: true })
+        KeePass4Web.fetch('group', {
+            method: 'PUT',
+            data: { id: this.props.group.id, title: titleDraft.trim() },
+            success: () => {
+                this.setState({ editingTitle: false, titleSaving: false })
+                if (this.props.onGroupRenamed) this.props.onGroupRenamed(this.props.group.id, titleDraft.trim())
+            },
+            error: (err) => {
+                this.setState({ titleSaving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
+    }
+
+    // ── render helpers ───────────────────────────────────────────────────────
+
+    renderPasswordInput(value, showField, onChangeFn, onToggleFn, onGenFn) {
+        const eyeIcon = showField ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
+        return (
+            <div className="input-group">
+                <input
+                    className="form-control"
+                    type={showField ? 'text' : 'password'}
+                    placeholder="Password (leave blank to keep existing)"
+                    value={value}
+                    onChange={onChangeFn}
+                />
+                <div className="input-group-btn">
+                    <button type="button" className="btn btn-default btn-sm" title="Show / hide" onClick={onToggleFn}>
+                        <span className={'glyphicon ' + eyeIcon}></span>
+                    </button>
+                    <button type="button" className="btn btn-default btn-sm" title="Generate random password" onClick={onGenFn}>
+                        <span className="glyphicon glyphicon-refresh"></span>
+                    </button>
+                </div>
+            </div>
+        )
+    }
+
+    renderEntryForm(form, showPw, onChangeFn, onTogglePw, onGenPw, onSubmitFn, onCancelFn, saving) {
+        return (
+            <tr key="entry-form">
+                <td colSpan="3">
+                    <form onSubmit={onSubmitFn}>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Title" required autoFocus
+                                value={form.title} onChange={onChangeFn.bind(this, 'title')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Username"
+                                value={form.username} onChange={onChangeFn.bind(this, 'username')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            {this.renderPasswordInput(
+                                form.password, showPw,
+                                onChangeFn.bind(this, 'password'),
+                                onTogglePw, onGenPw
+                            )}
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="URL"
+                                value={form.url} onChange={onChangeFn.bind(this, 'url')} />
+                        </div>
+                        <div className="form-group form-group-sm">
+                            <input className="form-control" placeholder="Notes"
+                                value={form.notes} onChange={onChangeFn.bind(this, 'notes')} />
+                        </div>
+                        <div className="btn-group">
+                            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
+                                {saving ? 'Saving…' : 'Save'}
+                            </button>
+                            <button type="button" className="btn btn-default btn-sm" onClick={onCancelFn}>
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
+                </td>
+            </tr>
+        )
+    }
+
+    render() {
+        const classes = Classnames({ 'panel': true, 'panel-default': true, 'loading-mask': this.props.mask })
 
         if (!this.props.group) return (<div className={classes}></div>)
 
         const group = this.props.group
         const isSearchResult = group.id === NIL_UUID
+        const canAddGroup = !isSearchResult && (this.props.groupDepth === undefined || this.props.groupDepth < 2)
+        const { editEntry, editingTitle, titleDraft, titleSaving, showGroupForm, newGroupName, groupSaving } = this.state
 
+        // ── group heading ────────────────────────────────────────────────────
+        let heading
+        if (editingTitle) {
+            heading = (
+                <form className="form-inline" onSubmit={this.onRenameSave.bind(this)}
+                      style={{ display: 'inline' }}>
+                    <div className="input-group input-group-sm" style={{ maxWidth: 260 }}>
+                        <input
+                            className="form-control"
+                            value={titleDraft}
+                            autoFocus
+                            onChange={e => this.setState({ titleDraft: e.target.value })}
+                        />
+                        <div className="input-group-btn">
+                            <button type="submit" className="btn btn-primary btn-sm" disabled={titleSaving}>
+                                {titleSaving ? '…' : <span className="glyphicon glyphicon-ok"></span>}
+                            </button>
+                            <button type="button" className="btn btn-default btn-sm"
+                                onClick={() => this.setState({ editingTitle: false })}>
+                                <span className="glyphicon glyphicon-remove"></span>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            )
+        } else {
+            heading = (
+                <span>
+                    {this.getIcon(group)}
+                    {group.title}
+                    {!isSearchResult && (
+                        <button className="btn btn-link btn-xs" style={{ padding: '0 4px' }}
+                            title="Rename group" onClick={this.onRenameStart.bind(this)}>
+                            <span className="glyphicon glyphicon-pencil"></span>
+                        </button>
+                    )}
+                </span>
+            )
+        }
+
+        // ── entry rows ───────────────────────────────────────────────────────
         let entries = []
         for (var i in group.entries) {
             let entry = group.entries[i]
+            const isEditing = editEntry && editEntry.id === entry.id
 
             entries.push(
-                <tr key={i} onClick={this.props.onSelect.bind(this, entry)}>
+                <tr key={entry.id} onClick={this.props.onSelect.bind(this, entry)}
+                    className={isEditing ? 'active' : ''}>
                     <td className="kp-wrap">
                         {this.getIcon(entry)}
                         {entry.title}
                     </td>
-                    <td className="kp-wrap">
-                        {entry.username}
-                    </td>
-                    <td>
-                        <button
-                            className="btn btn-danger btn-xs"
-                            title="Delete entry"
-                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}
-                        >
+                    <td className="kp-wrap">{entry.username}</td>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                        <button className="btn btn-default btn-xs" title="Edit entry"
+                            onClick={this.onEditEntry.bind(this, entry)}>
+                            <span className="glyphicon glyphicon-pencil"></span>
+                        </button>
+                        {' '}
+                        <button className="btn btn-danger btn-xs" title="Delete entry"
+                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}>
                             <span className="glyphicon glyphicon-trash"></span>
                         </button>
                     </td>
                 </tr>
             )
+
+            if (isEditing) {
+                entries.push(this.renderEntryForm(
+                    this.state.editForm,
+                    this.state.editShowPassword,
+                    this.onEditFormChange.bind(this),
+                    () => this.setState(p => ({ editShowPassword: !p.editShowPassword })),
+                    this.onEditGeneratePassword.bind(this),
+                    this.onEditSubmit.bind(this),
+                    () => this.setState({ editEntry: null }),
+                    this.state.editSaving,
+                ))
+            }
         }
 
+        // ── new entry form ───────────────────────────────────────────────────
         let newEntryForm = null
         if (this.state.showForm) {
-            const eyeIcon = this.state.showPassword ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
-            newEntryForm = (
-                <tr key="new-entry-form">
-                    <td colSpan="3">
-                        <form onSubmit={this.onSubmit}>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Title" required autoFocus
-                                    value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Username"
-                                    value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <div className="input-group">
-                                    <input
-                                        className="form-control"
-                                        type={this.state.showPassword ? 'text' : 'password'}
-                                        placeholder="Password"
-                                        value={this.state.form.password}
-                                        onChange={this.onFormChange.bind(this, 'password')}
-                                    />
-                                    <div className="input-group-btn">
-                                        <button type="button" className="btn btn-default btn-sm"
-                                            title="Show / hide password"
-                                            onClick={this.toggleShowPassword}>
-                                            <span className={'glyphicon ' + eyeIcon}></span>
-                                        </button>
-                                        <button type="button" className="btn btn-default btn-sm"
-                                            title="Generate random password"
-                                            onClick={this.onGeneratePassword}>
-                                            <span className="glyphicon glyphicon-refresh"></span>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="URL"
-                                    value={this.state.form.url} onChange={this.onFormChange.bind(this, 'url')} />
-                            </div>
-                            <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Notes"
-                                    value={this.state.form.notes} onChange={this.onFormChange.bind(this, 'notes')} />
-                            </div>
-                            <div className="btn-group">
-                                <button type="submit" className="btn btn-primary btn-sm" disabled={this.state.saving}>
-                                    {this.state.saving ? 'Saving…' : 'Save'}
-                                </button>
-                                <button type="button" className="btn btn-default btn-sm" onClick={this.onCancel}>
-                                    Cancel
-                                </button>
-                            </div>
-                        </form>
-                    </td>
-                </tr>
+            newEntryForm = this.renderEntryForm(
+                this.state.form,
+                this.state.showPassword,
+                this.onFormChange.bind(this),
+                () => this.setState(p => ({ showPassword: !p.showPassword })),
+                this.onGeneratePassword.bind(this),
+                this.onSubmit.bind(this),
+                this.onCancel.bind(this),
+                this.state.saving,
             )
         }
 
         return (
             <div className={classes}>
-                <div className="panel-heading">
-                    {this.getIcon(group)}
-                    {group.title}
-                    {!isSearchResult && (
-                        <button
-                            className="btn btn-success btn-xs pull-right"
-                            onClick={this.onNewEntry}
-                            title="New entry"
-                        >
-                            <span className="glyphicon glyphicon-plus"></span> New Entry
-                        </button>
+                <div className="panel-heading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span>{heading}</span>
+                    {!isSearchResult && !editingTitle && (
+                        <span>
+                            {canAddGroup && (
+                                <button className="btn btn-info btn-xs" style={{ marginRight: 4 }}
+                                    onClick={this.onNewGroup.bind(this)} title="Add subgroup">
+                                    <span className="glyphicon glyphicon-folder-open"></span> Add Group
+                                </button>
+                            )}
+                            <button className="btn btn-success btn-xs"
+                                onClick={this.onNewEntry.bind(this)} title="New entry">
+                                <span className="glyphicon glyphicon-plus"></span> New Entry
+                            </button>
+                        </span>
                     )}
                 </div>
+                {showGroupForm && (
+                    <div className="panel-body" style={{ paddingTop: 8, paddingBottom: 8, borderBottom: '1px solid #ddd' }}>
+                        <form className="form-inline" onSubmit={this.onGroupFormSubmit.bind(this)}>
+                            <div className="input-group input-group-sm" style={{ maxWidth: 300 }}>
+                                <input
+                                    className="form-control"
+                                    placeholder="Group name"
+                                    required
+                                    autoFocus
+                                    value={newGroupName}
+                                    onChange={e => this.setState({ newGroupName: e.target.value })}
+                                />
+                                <div className="input-group-btn">
+                                    <button type="submit" className="btn btn-primary btn-sm" disabled={groupSaving}>
+                                        {groupSaving ? '…' : 'Create'}
+                                    </button>
+                                    <button type="button" className="btn btn-default btn-sm"
+                                        onClick={() => this.setState({ showGroupForm: false })}>
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                )}
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">
                         <thead>

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -7,6 +7,15 @@ import withNavigateHook from './nagivateHook'
 class GroupViewer extends React.Component {
     constructor(props) {
         super(props)
+        this.state = {
+            showForm: false,
+            form: { title: '', username: '', password: '', url: '', notes: '' },
+            saving: false,
+        }
+        this.onNewEntry = this.onNewEntry.bind(this)
+        this.onFormChange = this.onFormChange.bind(this)
+        this.onSubmit = this.onSubmit.bind(this)
+        this.onCancel = this.onCancel.bind(this)
     }
 
     getIcon(element) {
@@ -14,6 +23,40 @@ class GroupViewer extends React.Component {
             return <img className="kp-icon" src={'api/v1/icon/' + encodeURIComponent(element.custom_icon_uuid)}/>
         else if (element.icon)
             return <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(element.icon) + '.png'}/>
+    }
+
+    onNewEntry() {
+        this.setState({ showForm: true, form: { title: '', username: '', password: '', url: '', notes: '' } })
+    }
+
+    onCancel() {
+        this.setState({ showForm: false })
+    }
+
+    onFormChange(field, e) {
+        this.setState(prev => ({ form: { ...prev.form, [field]: e.target.value } }))
+    }
+
+    onSubmit(e) {
+        e.preventDefault()
+        if (!this.props.group) return
+        this.setState({ saving: true })
+
+        KeePass4Web.fetch('entry', {
+            method: 'POST',
+            data: {
+                group_id: this.props.group.id,
+                ...this.state.form,
+            },
+            success: (data) => {
+                this.setState({ showForm: false, saving: false })
+                if (this.props.onEntryCreated) this.props.onEntryCreated(data && data.id)
+            },
+            error: (err) => {
+                this.setState({ saving: false })
+                KeePass4Web.error.call(this, err)
+            },
+        })
     }
 
     render() {
@@ -40,6 +83,55 @@ class GroupViewer extends React.Component {
                     <td className="kp-wrap">
                         {entry.username}
                     </td>
+                    <td>
+                        <button
+                            className="btn btn-danger btn-xs"
+                            title="Delete entry"
+                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}
+                        >
+                            <span className="glyphicon glyphicon-trash"></span>
+                        </button>
+                    </td>
+                </tr>
+            )
+        }
+
+        let newEntryForm = null
+        if (this.state.showForm) {
+            newEntryForm = (
+                <tr key="new-entry-form">
+                    <td colSpan="3">
+                        <form onSubmit={this.onSubmit}>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Title" required
+                                    value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Username"
+                                    value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" type="password" placeholder="Password"
+                                    value={this.state.form.password} onChange={this.onFormChange.bind(this, 'password')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="URL"
+                                    value={this.state.form.url} onChange={this.onFormChange.bind(this, 'url')} />
+                            </div>
+                            <div className="form-group form-group-sm">
+                                <input className="form-control" placeholder="Notes"
+                                    value={this.state.form.notes} onChange={this.onFormChange.bind(this, 'notes')} />
+                            </div>
+                            <div className="btn-group">
+                                <button type="submit" className="btn btn-primary btn-sm" disabled={this.state.saving}>
+                                    {this.state.saving ? 'Saving…' : 'Save'}
+                                </button>
+                                <button type="button" className="btn btn-default btn-sm" onClick={this.onCancel}>
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </td>
                 </tr>
             )
         }
@@ -49,21 +141,26 @@ class GroupViewer extends React.Component {
                 <div className="panel-heading">
                     {this.getIcon(group)}
                     {group.title}
+                    <button
+                        className="btn btn-success btn-xs pull-right"
+                        onClick={this.onNewEntry}
+                        title="New entry"
+                    >
+                        <span className="glyphicon glyphicon-plus"></span> New Entry
+                    </button>
                 </div>
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">
                         <thead>
                         <tr>
-                            <th>
-                                Entry Name
-                            </th>
-                            <th>
-                                Username
-                            </th>
+                            <th>Entry Name</th>
+                            <th>Username</th>
+                            <th></th>
                         </tr>
                         </thead>
                         <tbody className="groupview-body">
                         {entries}
+                        {newEntryForm}
                         </tbody>
                     </table>
                 </div>

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -3,6 +3,14 @@ import Classnames from 'classnames'
 
 import withNavigateHook from './nagivateHook'
 
+const NIL_UUID = '00000000-0000-0000-0000-000000000000'
+
+function generatePassword(length = 20) {
+    const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?'
+    const arr = new Uint8Array(length)
+    window.crypto.getRandomValues(arr)
+    return Array.from(arr).map(b => charset[b % charset.length]).join('')
+}
 
 class GroupViewer extends React.Component {
     constructor(props) {
@@ -11,11 +19,14 @@ class GroupViewer extends React.Component {
             showForm: false,
             form: { title: '', username: '', password: '', url: '', notes: '' },
             saving: false,
+            showPassword: false,
         }
         this.onNewEntry = this.onNewEntry.bind(this)
         this.onFormChange = this.onFormChange.bind(this)
         this.onSubmit = this.onSubmit.bind(this)
         this.onCancel = this.onCancel.bind(this)
+        this.onGeneratePassword = this.onGeneratePassword.bind(this)
+        this.toggleShowPassword = this.toggleShowPassword.bind(this)
     }
 
     getIcon(element) {
@@ -26,7 +37,7 @@ class GroupViewer extends React.Component {
     }
 
     onNewEntry() {
-        this.setState({ showForm: true, form: { title: '', username: '', password: '', url: '', notes: '' } })
+        this.setState({ showForm: true, showPassword: false, form: { title: '', username: '', password: '', url: '', notes: '' } })
     }
 
     onCancel() {
@@ -35,6 +46,15 @@ class GroupViewer extends React.Component {
 
     onFormChange(field, e) {
         this.setState(prev => ({ form: { ...prev.form, [field]: e.target.value } }))
+    }
+
+    onGeneratePassword() {
+        const pw = generatePassword()
+        this.setState(prev => ({ form: { ...prev.form, password: pw }, showPassword: true }))
+    }
+
+    toggleShowPassword() {
+        this.setState(prev => ({ showPassword: !prev.showPassword }))
     }
 
     onSubmit(e) {
@@ -69,6 +89,7 @@ class GroupViewer extends React.Component {
         if (!this.props.group) return (<div className={classes}></div>)
 
         const group = this.props.group
+        const isSearchResult = group.id === NIL_UUID
 
         let entries = []
         for (var i in group.entries) {
@@ -98,12 +119,13 @@ class GroupViewer extends React.Component {
 
         let newEntryForm = null
         if (this.state.showForm) {
+            const eyeIcon = this.state.showPassword ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
             newEntryForm = (
                 <tr key="new-entry-form">
                     <td colSpan="3">
                         <form onSubmit={this.onSubmit}>
                             <div className="form-group form-group-sm">
-                                <input className="form-control" placeholder="Title" required
+                                <input className="form-control" placeholder="Title" required autoFocus
                                     value={this.state.form.title} onChange={this.onFormChange.bind(this, 'title')} />
                             </div>
                             <div className="form-group form-group-sm">
@@ -111,8 +133,27 @@ class GroupViewer extends React.Component {
                                     value={this.state.form.username} onChange={this.onFormChange.bind(this, 'username')} />
                             </div>
                             <div className="form-group form-group-sm">
-                                <input className="form-control" type="password" placeholder="Password"
-                                    value={this.state.form.password} onChange={this.onFormChange.bind(this, 'password')} />
+                                <div className="input-group">
+                                    <input
+                                        className="form-control"
+                                        type={this.state.showPassword ? 'text' : 'password'}
+                                        placeholder="Password"
+                                        value={this.state.form.password}
+                                        onChange={this.onFormChange.bind(this, 'password')}
+                                    />
+                                    <div className="input-group-btn">
+                                        <button type="button" className="btn btn-default btn-sm"
+                                            title="Show / hide password"
+                                            onClick={this.toggleShowPassword}>
+                                            <span className={'glyphicon ' + eyeIcon}></span>
+                                        </button>
+                                        <button type="button" className="btn btn-default btn-sm"
+                                            title="Generate random password"
+                                            onClick={this.onGeneratePassword}>
+                                            <span className="glyphicon glyphicon-refresh"></span>
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
                             <div className="form-group form-group-sm">
                                 <input className="form-control" placeholder="URL"
@@ -141,13 +182,15 @@ class GroupViewer extends React.Component {
                 <div className="panel-heading">
                     {this.getIcon(group)}
                     {group.title}
-                    <button
-                        className="btn btn-success btn-xs pull-right"
-                        onClick={this.onNewEntry}
-                        title="New entry"
-                    >
-                        <span className="glyphicon glyphicon-plus"></span> New Entry
-                    </button>
+                    {!isSearchResult && (
+                        <button
+                            className="btn btn-success btn-xs pull-right"
+                            onClick={this.onNewEntry}
+                            title="New entry"
+                        >
+                            <span className="glyphicon glyphicon-plus"></span> New Entry
+                        </button>
+                    )}
                 </div>
                 <div className="panel-body">
                     <table className="table table-hover table-condensed kp-table">

--- a/js/scripts/GroupViewer.js
+++ b/js/scripts/GroupViewer.js
@@ -1,138 +1,70 @@
 import React from 'react'
-import Classnames from 'classnames'
-
 import withNavigateHook from './nagivateHook'
+import {
+    IconPlus, IconPencil, IconTrash, IconLock, IconCheck, IconX, IconFolder, IconMonitor, IconDatabase,
+} from './Icons'
 
 const NIL_UUID = '00000000-0000-0000-0000-000000000000'
 
-function generatePassword(length = 20) {
-    const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?'
-    const arr = new Uint8Array(length)
-    window.crypto.getRandomValues(arr)
-    return Array.from(arr).map(b => charset[b % charset.length]).join('')
+function entryIcon(entry) {
+    if (entry.custom_icon_uuid)
+        return <img style={{ width: 18, height: 18, objectFit: 'contain' }}
+                    src={'api/v1/icon/' + encodeURIComponent(entry.custom_icon_uuid)} alt=""/>
+    if (entry.url && entry.url.includes('db'))
+        return <IconDatabase size={18}/>
+    return <IconMonitor size={18}/>
 }
-
-const EMPTY_FORM = { title: '', username: '', password: '', url: '', notes: '' }
 
 class GroupViewer extends React.Component {
     constructor(props) {
         super(props)
         this.state = {
-            // new entry form
-            showForm: false,
-            form: { ...EMPTY_FORM },
-            saving: false,
-            showPassword: false,
-            // edit entry
-            editEntry: null,
-            editForm: { ...EMPTY_FORM },
-            editSaving: false,
-            editShowPassword: false,
-            // rename group
-            editingTitle: false,
-            titleDraft: '',
-            titleSaving: false,
-            // new group
+            // group rename
+            editingTitle:  false,
+            titleDraft:    '',
+            titleSaving:   false,
+            // add subgroup
             showGroupForm: false,
-            newGroupName: '',
-            groupSaving: false,
+            newGroupName:  '',
+            groupSaving:   false,
         }
     }
 
-    getIcon(element) {
-        if (element.custom_icon_uuid)
-            return <img className="kp-icon" src={'api/v1/icon/' + encodeURIComponent(element.custom_icon_uuid)}/>
-        else if (element.icon)
-            return <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(element.icon) + '.png'}/>
+    // ── Group rename ─────────────────────────────────────────────
+
+    startRename() {
+        this.setState({ editingTitle: true, titleDraft: this.props.group.title })
     }
 
-    // ── new entry ────────────────────────────────────────────────────────────
-
-    onNewEntry() {
-        this.setState({ showForm: true, showPassword: false, form: { ...EMPTY_FORM }, editEntry: null })
-    }
-
-    onCancel() {
-        this.setState({ showForm: false })
-    }
-
-    onFormChange(field, e) {
-        this.setState(prev => ({ form: { ...prev.form, [field]: e.target.value } }))
-    }
-
-    onGeneratePassword() {
-        this.setState(prev => ({ form: { ...prev.form, password: generatePassword() }, showPassword: true }))
-    }
-
-    onSubmit(e) {
+    saveRename(e) {
         e.preventDefault()
-        if (!this.props.group) return
-        this.setState({ saving: true })
-        KeePass4Web.fetch('entry', {
-            method: 'POST',
-            data: { group_id: this.props.group.id, ...this.state.form },
-            success: (data) => {
-                this.setState({ showForm: false, saving: false })
-                if (this.props.onEntryCreated) this.props.onEntryCreated(data && data.id)
-            },
-            error: (err) => {
-                this.setState({ saving: false })
-                KeePass4Web.error.call(this, err)
-            },
-        })
-    }
-
-    // ── edit entry ───────────────────────────────────────────────────────────
-
-    onEditEntry(entry, ev) {
-        ev.stopPropagation()
-        this.setState({
-            editEntry: entry,
-            editForm: { title: entry.title || '', username: entry.username || '', password: '', url: entry.url || '', notes: '' },
-            editShowPassword: false,
-            showForm: false,
-        })
-    }
-
-    onEditFormChange(field, e) {
-        this.setState(prev => ({ editForm: { ...prev.editForm, [field]: e.target.value } }))
-    }
-
-    onEditGeneratePassword() {
-        this.setState(prev => ({ editForm: { ...prev.editForm, password: generatePassword() }, editShowPassword: true }))
-    }
-
-    onEditSubmit(e) {
-        e.preventDefault()
-        const { editEntry, editForm } = this.state
-        this.setState({ editSaving: true })
-        KeePass4Web.fetch('entry', {
+        const name = this.state.titleDraft.trim()
+        if (!name) return
+        this.setState({ titleSaving: true })
+        KeePass4Web.fetch('group', {
             method: 'PUT',
-            data: { id: editEntry.id, ...editForm },
+            data: { id: this.props.group.id, title: name },
             success: () => {
-                this.setState({ editEntry: null, editSaving: false })
-                if (this.props.onEntryCreated) this.props.onEntryCreated()
+                this.setState({ editingTitle: false, titleSaving: false })
+                if (this.props.onGroupRenamed) this.props.onGroupRenamed(this.props.group.id, name)
             },
             error: (err) => {
-                this.setState({ editSaving: false })
+                this.setState({ titleSaving: false })
                 KeePass4Web.error.call(this, err)
             },
         })
     }
 
-    // ── create group ─────────────────────────────────────────────────────────
+    // ── Create subgroup ──────────────────────────────────────────
 
-    onNewGroup() {
-        this.setState({ showGroupForm: true, newGroupName: '', showForm: false, editEntry: null })
-    }
-
-    onGroupFormSubmit(e) {
+    saveGroup(e) {
         e.preventDefault()
-        if (!this.props.group || !this.state.newGroupName.trim()) return
+        const name = this.state.newGroupName.trim()
+        if (!name) return
         this.setState({ groupSaving: true })
         KeePass4Web.fetch('group', {
             method: 'POST',
-            data: { parent_id: this.props.group.id, title: this.state.newGroupName.trim() },
+            data: { parent_id: this.props.group.id, title: name },
             success: () => {
                 this.setState({ showGroupForm: false, newGroupName: '', groupSaving: false })
                 if (this.props.onGroupCreated) this.props.onGroupCreated()
@@ -144,263 +76,174 @@ class GroupViewer extends React.Component {
         })
     }
 
-    // ── rename group ─────────────────────────────────────────────────────────
+    // ── Delete entry ─────────────────────────────────────────────
 
-    onRenameStart() {
-        this.setState({ editingTitle: true, titleDraft: this.props.group.title })
-    }
-
-    onRenameSave(e) {
-        e.preventDefault()
-        const { titleDraft } = this.state
-        if (!titleDraft.trim()) return
-        this.setState({ titleSaving: true })
-        KeePass4Web.fetch('group', {
-            method: 'PUT',
-            data: { id: this.props.group.id, title: titleDraft.trim() },
-            success: () => {
-                this.setState({ editingTitle: false, titleSaving: false })
-                if (this.props.onGroupRenamed) this.props.onGroupRenamed(this.props.group.id, titleDraft.trim())
-            },
-            error: (err) => {
-                this.setState({ titleSaving: false })
-                KeePass4Web.error.call(this, err)
-            },
+    deleteEntry(entry, e) {
+        e.stopPropagation()
+        if (!window.confirm(`Delete "${entry.title}"?`)) return
+        KeePass4Web.fetch('entry', {
+            method: 'DELETE',
+            data: { id: entry.id },
+            success: () => { if (this.props.onEntryDeleted) this.props.onEntryDeleted() },
+            error: KeePass4Web.error.bind(this),
         })
     }
 
-    // ── render helpers ───────────────────────────────────────────────────────
-
-    renderPasswordInput(value, showField, onChangeFn, onToggleFn, onGenFn) {
-        const eyeIcon = showField ? 'glyphicon-eye-close' : 'glyphicon-eye-open'
-        return (
-            <div className="input-group">
-                <input
-                    className="form-control"
-                    type={showField ? 'text' : 'password'}
-                    placeholder="Password (leave blank to keep existing)"
-                    value={value}
-                    onChange={onChangeFn}
-                />
-                <div className="input-group-btn">
-                    <button type="button" className="btn btn-default btn-sm" title="Show / hide" onClick={onToggleFn}>
-                        <span className={'glyphicon ' + eyeIcon}></span>
-                    </button>
-                    <button type="button" className="btn btn-default btn-sm" title="Generate random password" onClick={onGenFn}>
-                        <span className="glyphicon glyphicon-refresh"></span>
-                    </button>
-                </div>
-            </div>
-        )
-    }
-
-    renderEntryForm(form, showPw, onChangeFn, onTogglePw, onGenPw, onSubmitFn, onCancelFn, saving) {
-        return (
-            <tr key="entry-form">
-                <td colSpan="3">
-                    <form onSubmit={onSubmitFn}>
-                        <div className="form-group form-group-sm">
-                            <input className="form-control" placeholder="Title" required autoFocus
-                                value={form.title} onChange={onChangeFn.bind(this, 'title')} />
-                        </div>
-                        <div className="form-group form-group-sm">
-                            <input className="form-control" placeholder="Username"
-                                value={form.username} onChange={onChangeFn.bind(this, 'username')} />
-                        </div>
-                        <div className="form-group form-group-sm">
-                            {this.renderPasswordInput(
-                                form.password, showPw,
-                                onChangeFn.bind(this, 'password'),
-                                onTogglePw, onGenPw
-                            )}
-                        </div>
-                        <div className="form-group form-group-sm">
-                            <input className="form-control" placeholder="URL"
-                                value={form.url} onChange={onChangeFn.bind(this, 'url')} />
-                        </div>
-                        <div className="form-group form-group-sm">
-                            <input className="form-control" placeholder="Notes"
-                                value={form.notes} onChange={onChangeFn.bind(this, 'notes')} />
-                        </div>
-                        <div className="btn-group">
-                            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
-                                {saving ? 'Saving…' : 'Save'}
-                            </button>
-                            <button type="button" className="btn btn-default btn-sm" onClick={onCancelFn}>
-                                Cancel
-                            </button>
-                        </div>
-                    </form>
-                </td>
-            </tr>
-        )
-    }
-
     render() {
-        const classes = Classnames({ 'panel': true, 'panel-default': true, 'loading-mask': this.props.mask })
+        const { group, groupDepth, selectedEntryId, onSelect, onNewEntry, onEditEntry, mask } = this.props
+        const { editingTitle, titleDraft, titleSaving, showGroupForm, newGroupName, groupSaving } = this.state
 
-        if (!this.props.group) return (<div className={classes}></div>)
+        const panelClass = `kp-center${mask ? ' kp-loading' : ''}`
+        if (!group) return <div className="kp-center"/>
 
-        const group = this.props.group
-        const isSearchResult = group.id === NIL_UUID
-        const canAddGroup = !isSearchResult && (this.props.groupDepth === undefined || this.props.groupDepth < 2)
-        const { editEntry, editingTitle, titleDraft, titleSaving, showGroupForm, newGroupName, groupSaving } = this.state
+        const isSearch    = group.id === NIL_UUID
+        const canAddGroup = !isSearch && (groupDepth === undefined || groupDepth < 2)
 
-        // ── group heading ────────────────────────────────────────────────────
-        let heading
+        // ── heading ──────────────────────────────────────────────
+        let titleEl
         if (editingTitle) {
-            heading = (
-                <form className="form-inline" onSubmit={this.onRenameSave.bind(this)}
-                      style={{ display: 'inline' }}>
-                    <div className="input-group input-group-sm" style={{ maxWidth: 260 }}>
-                        <input
-                            className="form-control"
-                            value={titleDraft}
-                            autoFocus
-                            onChange={e => this.setState({ titleDraft: e.target.value })}
-                        />
-                        <div className="input-group-btn">
-                            <button type="submit" className="btn btn-primary btn-sm" disabled={titleSaving}>
-                                {titleSaving ? '…' : <span className="glyphicon glyphicon-ok"></span>}
-                            </button>
-                            <button type="button" className="btn btn-default btn-sm"
-                                onClick={() => this.setState({ editingTitle: false })}>
-                                <span className="glyphicon glyphicon-remove"></span>
-                            </button>
-                        </div>
-                    </div>
+            titleEl = (
+                <form className="kp-center-title-form" onSubmit={this.saveRename.bind(this)}>
+                    <input
+                        className="kp-input"
+                        value={titleDraft}
+                        autoFocus
+                        style={{ maxWidth: 200, padding: '4px 8px', fontSize: 15, fontWeight: 600 }}
+                        onChange={e => this.setState({ titleDraft: e.target.value })}
+                    />
+                    <button type="submit" className="kp-btn-icon" title="Save" disabled={titleSaving}>
+                        <IconCheck size={14}/>
+                    </button>
+                    <button type="button" className="kp-btn-icon" title="Cancel"
+                            onClick={() => this.setState({ editingTitle: false })}>
+                        <IconX size={14}/>
+                    </button>
                 </form>
             )
         } else {
-            heading = (
-                <span>
-                    {this.getIcon(group)}
-                    {group.title}
-                    {!isSearchResult && (
-                        <button className="btn btn-link btn-xs" style={{ padding: '0 4px' }}
-                            title="Rename group" onClick={this.onRenameStart.bind(this)}>
-                            <span className="glyphicon glyphicon-pencil"></span>
-                        </button>
-                    )}
-                </span>
+            titleEl = (
+                <div className="kp-center-title">
+                    <h2>
+                        {group.title}
+                        {!isSearch && (
+                            <button
+                                className="kp-btn-link"
+                                title="Rename group"
+                                onClick={this.startRename.bind(this)}
+                                style={{ marginLeft: 6 }}
+                            >
+                                <IconPencil size={13}/>
+                            </button>
+                        )}
+                    </h2>
+                    <small>
+                        {(group.entries || []).length} saved entr{(group.entries || []).length !== 1 ? 'ies' : 'y'}
+                    </small>
+                </div>
             )
         }
 
-        // ── entry rows ───────────────────────────────────────────────────────
-        let entries = []
-        for (var i in group.entries) {
-            let entry = group.entries[i]
-            const isEditing = editEntry && editEntry.id === entry.id
-
-            entries.push(
-                <tr key={entry.id} onClick={this.props.onSelect.bind(this, entry)}
-                    className={isEditing ? 'active' : ''}>
-                    <td className="kp-wrap">
-                        {this.getIcon(entry)}
-                        {entry.title}
-                    </td>
-                    <td className="kp-wrap">{entry.username}</td>
-                    <td style={{ whiteSpace: 'nowrap' }}>
-                        <button className="btn btn-default btn-xs" title="Edit entry"
-                            onClick={this.onEditEntry.bind(this, entry)}>
-                            <span className="glyphicon glyphicon-pencil"></span>
-                        </button>
-                        {' '}
-                        <button className="btn btn-danger btn-xs" title="Delete entry"
-                            onClick={(ev) => { ev.stopPropagation(); this.props.onDeleteEntry && this.props.onDeleteEntry(entry) }}>
-                            <span className="glyphicon glyphicon-trash"></span>
-                        </button>
-                    </td>
-                </tr>
-            )
-
-            if (isEditing) {
-                entries.push(this.renderEntryForm(
-                    this.state.editForm,
-                    this.state.editShowPassword,
-                    this.onEditFormChange.bind(this),
-                    () => this.setState(p => ({ editShowPassword: !p.editShowPassword })),
-                    this.onEditGeneratePassword.bind(this),
-                    this.onEditSubmit.bind(this),
-                    () => this.setState({ editEntry: null }),
-                    this.state.editSaving,
-                ))
-            }
-        }
-
-        // ── new entry form ───────────────────────────────────────────────────
-        let newEntryForm = null
-        if (this.state.showForm) {
-            newEntryForm = this.renderEntryForm(
-                this.state.form,
-                this.state.showPassword,
-                this.onFormChange.bind(this),
-                () => this.setState(p => ({ showPassword: !p.showPassword })),
-                this.onGeneratePassword.bind(this),
-                this.onSubmit.bind(this),
-                this.onCancel.bind(this),
-                this.state.saving,
-            )
-        }
+        // ── entry cards ──────────────────────────────────────────
+        const cards = (group.entries || []).map(entry => (
+            <div
+                key={entry.id}
+                className={`kp-card${selectedEntryId === entry.id ? ' active' : ''}`}
+                onClick={() => onSelect && onSelect(entry)}
+            >
+                <div className="kp-card-icon">
+                    {entryIcon(entry)}
+                </div>
+                <div className="kp-card-body">
+                    <div className="kp-card-title">{entry.title}</div>
+                    <div className="kp-card-meta">
+                        {[entry.username, entry.url].filter(Boolean).join(' · ')}
+                    </div>
+                </div>
+                <div className="kp-card-actions">
+                    <button
+                        className="kp-btn-icon"
+                        title="Edit entry"
+                        onClick={ev => { ev.stopPropagation(); onEditEntry && onEditEntry(entry) }}
+                    >
+                        <IconPencil size={13}/>
+                    </button>
+                    <button
+                        className="kp-btn-icon"
+                        title="Delete entry"
+                        style={{ color: 'var(--kp-text-muted)' }}
+                        onClick={this.deleteEntry.bind(this, entry)}
+                    >
+                        <IconTrash size={13}/>
+                    </button>
+                </div>
+            </div>
+        ))
 
         return (
-            <div className={classes}>
-                <div className="panel-heading" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                    <span>{heading}</span>
-                    {!isSearchResult && !editingTitle && (
-                        <span>
+            <div className={panelClass}>
+                <div className="kp-center-header">
+                    {titleEl}
+
+                    {!editingTitle && (
+                        <div className="kp-center-actions">
+                            {group.entries && group.entries.length > 0 && (
+                                <span className="kp-badge kp-badge-protected">
+                                    <IconLock size={11}/>
+                                    protected
+                                </span>
+                            )}
                             {canAddGroup && (
-                                <button className="btn btn-info btn-xs" style={{ marginRight: 4 }}
-                                    onClick={this.onNewGroup.bind(this)} title="Add subgroup">
-                                    <span className="glyphicon glyphicon-folder-open"></span> Add Group
+                                <button
+                                    className="kp-btn kp-btn-ghost kp-btn-sm"
+                                    onClick={() => this.setState({ showGroupForm: true, newGroupName: '' })}
+                                    title="Add subgroup"
+                                >
+                                    <IconFolder size={13}/>
+                                    Add Group
                                 </button>
                             )}
-                            <button className="btn btn-success btn-xs"
-                                onClick={this.onNewEntry.bind(this)} title="New entry">
-                                <span className="glyphicon glyphicon-plus"></span> New Entry
-                            </button>
-                        </span>
+                            {!isSearch && (
+                                <button
+                                    className="kp-btn kp-btn-primary kp-btn-sm"
+                                    onClick={() => onNewEntry && onNewEntry()}
+                                >
+                                    <IconPlus size={13}/>
+                                    New Entry
+                                </button>
+                            )}
+                        </div>
                     )}
                 </div>
+
+                {/* Add-group form */}
                 {showGroupForm && (
-                    <div className="panel-body" style={{ paddingTop: 8, paddingBottom: 8, borderBottom: '1px solid #ddd' }}>
-                        <form className="form-inline" onSubmit={this.onGroupFormSubmit.bind(this)}>
-                            <div className="input-group input-group-sm" style={{ maxWidth: 300 }}>
-                                <input
-                                    className="form-control"
-                                    placeholder="Group name"
-                                    required
-                                    autoFocus
-                                    value={newGroupName}
-                                    onChange={e => this.setState({ newGroupName: e.target.value })}
-                                />
-                                <div className="input-group-btn">
-                                    <button type="submit" className="btn btn-primary btn-sm" disabled={groupSaving}>
-                                        {groupSaving ? '…' : 'Create'}
-                                    </button>
-                                    <button type="button" className="btn btn-default btn-sm"
-                                        onClick={() => this.setState({ showGroupForm: false })}>
-                                        Cancel
-                                    </button>
-                                </div>
-                            </div>
+                    <div className="kp-group-form">
+                        <form onSubmit={this.saveGroup.bind(this)}>
+                            <input
+                                className="kp-input"
+                                placeholder="Group name"
+                                required autoFocus
+                                value={newGroupName}
+                                style={{ maxWidth: 260 }}
+                                onChange={e => this.setState({ newGroupName: e.target.value })}
+                            />
+                            <button type="submit" className="kp-btn kp-btn-primary kp-btn-sm" disabled={groupSaving}>
+                                {groupSaving ? '…' : 'Create'}
+                            </button>
+                            <button type="button" className="kp-btn kp-btn-outline kp-btn-sm"
+                                    onClick={() => this.setState({ showGroupForm: false })}>
+                                Cancel
+                            </button>
                         </form>
                     </div>
                 )}
-                <div className="panel-body">
-                    <table className="table table-hover table-condensed kp-table">
-                        <thead>
-                        <tr>
-                            <th>Entry Name</th>
-                            <th>Username</th>
-                            <th></th>
-                        </tr>
-                        </thead>
-                        <tbody className="groupview-body">
-                        {entries}
-                        {newEntryForm}
-                        </tbody>
-                    </table>
+
+                <div className="kp-entries">
+                    {cards.length > 0 ? cards : (
+                        <div style={{ padding: '40px 0', textAlign: 'center', color: 'var(--kp-text-muted)', fontSize: 13 }}>
+                            No entries yet. Click <strong>+ New Entry</strong> to add one.
+                        </div>
+                    )}
                 </div>
             </div>
         )

--- a/js/scripts/Icons.js
+++ b/js/scripts/Icons.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+const icon = (d, size = 16) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+         stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        {d}
+    </svg>
+)
+
+export const IconShield     = ({size} = {}) => icon(<path d="M12 2 3 7v6c0 5.25 3.75 10.15 9 11.25C17.25 23.15 21 18.25 21 13V7z"/>, size)
+export const IconSearch     = ({size} = {}) => icon(<><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></>, size)
+export const IconUser       = ({size} = {}) => icon(<><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>, size)
+export const IconChevDown   = ({size} = {}) => icon(<path d="m6 9 6 6 6-6"/>, size)
+export const IconChevRight  = ({size} = {}) => icon(<path d="m9 18 6-6-6-6"/>, size)
+export const IconSync       = ({size} = {}) => icon(<><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/></>, size)
+export const IconSave       = ({size} = {}) => icon(<><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></>, size)
+export const IconFolder     = ({size} = {}) => icon(<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>, size)
+export const IconFolderRoot = ({size} = {}) => icon(<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>, size)
+export const IconPlus       = ({size} = {}) => icon(<><path d="M12 5v14"/><path d="M5 12h14"/></>, size)
+export const IconPencil     = ({size} = {}) => icon(<><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"/></>, size)
+export const IconTrash      = ({size} = {}) => icon(<><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/></>, size)
+export const IconEye        = ({size} = {}) => icon(<><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></>, size)
+export const IconEyeOff     = ({size} = {}) => icon(<><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></>, size)
+export const IconRefresh    = ({size} = {}) => icon(<><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2 11.5a10 10 0 0 1 18.8-4.3"/><path d="M22 12.5a10 10 0 0 1-18.8 4.3"/></>, size)
+export const IconCopy       = ({size} = {}) => icon(<><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>, size)
+export const IconLock       = ({size} = {}) => icon(<><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></>, size)
+export const IconCheck      = ({size} = {}) => icon(<polyline points="20 6 9 17 4 12"/>, size)
+export const IconX          = ({size} = {}) => icon(<><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></>, size)
+export const IconDownload   = ({size} = {}) => icon(<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></>, size)
+export const IconKey        = ({size} = {}) => icon(<><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></>, size)
+export const IconMenu       = ({size} = {}) => icon(<><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></>, size)
+export const IconMonitor    = ({size} = {}) => icon(<><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></>, size)
+export const IconDatabase   = ({size} = {}) => icon(<><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/></>, size)
+export const IconUpload     = ({size} = {}) => icon(<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></>, size)
+export const IconMoon       = ({size} = {}) => icon(<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>, size)
+export const IconSun        = ({size} = {}) => icon(<><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></>, size)

--- a/js/scripts/NavBar.js
+++ b/js/scripts/NavBar.js
@@ -118,6 +118,17 @@ class NavBar extends React.Component {
             }
         }
 
+        const saveBtn = this.props.onSaveDb ? (
+            <ul className="nav navbar-nav navbar-right">
+                <li>
+                    <a href="" onClick={(e) => { e.preventDefault(); this.props.onSaveDb() }}
+                       title="Save database to disk">
+                        <span className="glyphicon glyphicon-floppy-disk"></span> Save
+                    </a>
+                </li>
+            </ul>
+        ) : null
+
         return (
             <nav className="navbar navbar-default navbar-fixed-top">
                 <div className="navbar-header">
@@ -133,6 +144,7 @@ class NavBar extends React.Component {
                 </div>
                 <div className="collapse navbar-collapse" id="navbar-collapse-1">
                     {search}
+                    {saveBtn}
                     <ul className="nav navbar-nav navbar-right">
                         <li className="dropdown">
                             <a href="" className="dropdown-toggle" data-toggle="dropdown" role="button"

--- a/js/scripts/NavBar.js
+++ b/js/scripts/NavBar.js
@@ -1,7 +1,19 @@
 import React from 'react'
-import {Link} from "react-router-dom"
+import { Link } from 'react-router-dom'
 import Timer from './Timer'
 import withNavigateHook from './nagivateHook'
+import {
+    IconShield, IconSearch, IconUser, IconChevDown,
+    IconSync, IconSave, IconX, IconMenu, IconMoon, IconSun,
+} from './Icons'
+
+function getTheme() {
+    return localStorage.getItem('kp-theme') || 'light'
+}
+function applyTheme(t) {
+    document.documentElement.setAttribute('data-theme', t)
+    localStorage.setItem('kp-theme', t)
+}
 
 window.$ = window.jQuery = require('jquery')
 require('bootstrap')
@@ -9,152 +21,208 @@ require('bootstrap')
 class NavBar extends React.Component {
     constructor(props) {
         super(props)
-        this.onLogout = this.onLogout.bind(this)
-        this.onCloseDB = this.onCloseDB.bind(this)
-        this.onTimeUp = this.onTimeUp.bind(this)
+        this.state = { dropdownOpen: false, theme: getTheme() }
+        this.onLogout   = this.onLogout.bind(this)
+        this.onCloseDB  = this.onCloseDB.bind(this)
+        this.onTimeUp   = this.onTimeUp.bind(this)
+        this.closeDropdown = this.closeDropdown.bind(this)
     }
 
     onLogout() {
         this.serverRequest = KeePass4Web.fetch('logout', {
-            success: function (data) {
+            success: (data) => {
                 KeePass4Web.clearStorage()
                 if (data && data.type === 'redirect' && data.url) {
                     window.location = data.url
                 } else {
-                    this.props.navigate('/', {replace: true})
+                    this.props.navigate('/', { replace: true })
                 }
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
         })
     }
 
-    onCloseDB(event, state) {
+    onCloseDB(e, state) {
         this.serverRequest = KeePass4Web.fetch('close_db', {
-            success: function () {
-                // redirect to home, so checks for proper login can be made
-                this.props.navigate('/', {state: state, replace: true})
-            }.bind(this),
+            success: () => this.props.navigate('/', { state, replace: true }),
             error: KeePass4Web.error.bind(this),
         })
     }
 
     onTimeUp() {
-        this.onCloseDB(null, {
-            info: 'Database session expired'
-        })
+        this.onCloseDB(null, { info: 'Database session expired' })
+    }
+
+    closeDropdown(e) {
+        if (!e.target.closest('.kp-dropdown')) {
+            this.setState({ dropdownOpen: false })
+        }
+    }
+
+    toggleTheme() {
+        const next = this.state.theme === 'light' ? 'dark' : 'light'
+        applyTheme(next)
+        this.setState({ theme: next })
     }
 
     componentDidMount() {
-        if (KeePass4Web.getSettings().cn) {
-            document.getElementById('logout').addEventListener('click', this.onLogout)
-            document.getElementById('closeDB').addEventListener('click', this.onCloseDB)
-        }
+        applyTheme(this.state.theme)
+        document.addEventListener('click', this.closeDropdown)
     }
 
     componentWillUnmount() {
-        if (this.serverRequest)
-            this.serverRequest.abort()
+        document.removeEventListener('click', this.closeDropdown)
+        if (this.serverRequest) this.serverRequest.abort()
     }
 
     render() {
-        let cn = KeePass4Web.getSettings().cn;
-        let dropdown, search, timer;
-        if (cn) {
-            let closeDbHidden = true;
-            if (
-                this.props.location
-                && this.props.location.pathname !== '/backend_login'
-                && this.props.location.pathname !== '/db_login'
-            ) {
-                closeDbHidden = false
-            }
+        const cn = KeePass4Web.getSettings().cn
+        const loc = this.props.location
+        const isVault = loc && loc.pathname !== '/backend_login' && loc.pathname !== '/db_login'
 
-            dropdown = (
-                <ul className="dropdown-menu">
-                    <li><a id="logout">Logout</a></li>
-                    <li role="separator" className="divider"></li>
-                    <li><a id="closeDB" style={closeDbHidden ? {visibility: 'hidden'} : {}}>Close Database</a></li>
-                </ul>
-            )
-        } else {
-            cn = 'Not logged in'
-            dropdown = (
-                <ul className="dropdown-menu">
-                    <li><Link to="/" replace>Login</Link></li>
-                </ul>
+        // Only render the full vault nav when logged in and past login screens
+        if (!cn) {
+            return (
+                <nav className="kp-nav">
+                    <Link className="kp-nav-brand" to="/" replace>
+                        <IconShield size={20}/>
+                        KeePass 4 Web
+                    </Link>
+                    <div className="kp-nav-spacer"/>
+                    <Link className="kp-btn kp-btn-ghost" to="/" replace>Login</Link>
+                </nav>
             )
         }
 
+        // Session timer
+        let timer = null
+        const timeout = KeePass4Web.getSettings().timeout
+        if (timeout && this.props.showSearch) {
+            timer = (
+                <span className="kp-nav-status" style={{ gap: 8 }}>
+                    <Timer
+                        format='{hh}:{mm}:{ss}'
+                        timeout={timeout}
+                        onTimeUp={this.onTimeUp}
+                        restart={KeePass4Web.restartTimer}
+                    />
+                    <button
+                        className="kp-btn-icon"
+                        style={{ padding: '4px 6px' }}
+                        onClick={() => KeePass4Web.restartTimer(true)}
+                        title="Reset timer"
+                    >
+                        <IconSync size={13}/>
+                    </button>
+                </span>
+            )
+        }
+
+        // Search box
+        let search = null
         if (this.props.showSearch) {
             search = (
-                <form className="navbar-form navbar-left" role="search"
-                      onSubmit={this.props.onSearch.bind(this, this.refs)}>
-                    <div className="input-group">
-                        <input autoComplete="on" type="search" ref="term" className="form-control" placeholder="Search"
-                               autoFocus/>
-                        <div className="input-group-btn">
-                            <button type="submit" className="btn btn-default"><span
-                                className="glyphicon glyphicon-search"></span></button>
-                        </div>
-                    </div>
+                <form
+                    className="kp-nav-search"
+                    role="search"
+                    onSubmit={e => this.props.onSearch && this.props.onSearch(this.searchRef, e)}
+                >
+                    <IconSearch size={14}/>
+                    <input
+                        type="search"
+                        placeholder="Search entries, usernames, URLs…"
+                        autoComplete="on"
+                        ref={r => (this.searchRef = { term: r })}
+                    />
                 </form>
             )
-            let timeout = KeePass4Web.getSettings().timeout
-            if (timeout) {
-                timer = (
-                    <div className="navbar-text">
-                        <Timer
-                            format='{hh}:{mm}:{ss}'
-                            timeout={timeout}
-                            onTimeUp={this.onTimeUp}
-                            restart={KeePass4Web.restartTimer}
-                        />
-                        <label type="button" className="btn btn-secondary btn-xs"
-                               onClick={KeePass4Web.restartTimer.bind(this, true)}>
-                            <span className="glyphicon glyphicon-repeat"></span>
-                        </label>
-                    </div>
-                )
-            }
         }
 
-        const saveBtn = this.props.onSaveDb ? (
-            <ul className="nav navbar-nav navbar-right">
-                <li>
-                    <a href="" onClick={(e) => { e.preventDefault(); this.props.onSaveDb() }}
-                       title="Save database to disk">
-                        <span className="glyphicon glyphicon-floppy-disk"></span> Save
-                    </a>
-                </li>
-            </ul>
+        // Mobile sidebar toggle
+        const sidebarToggle = this.props.onToggleSidebar ? (
+            <button
+                className="kp-btn kp-btn-ghost kp-sidebar-toggle"
+                style={{ display: 'none', padding: '7px 8px' }}
+                onClick={this.props.onToggleSidebar}
+                aria-label="Toggle sidebar"
+            >
+                <IconMenu size={18}/>
+            </button>
         ) : null
 
         return (
-            <nav className="navbar navbar-default navbar-fixed-top">
-                <div className="navbar-header">
-                    <button type="button" className="navbar-toggle collapsed" data-toggle="collapse"
-                            data-target="#navbar-collapse-1" aria-expanded="false">
-                        <span className="sr-only">Toggle navigation</span>
-                        <span className="icon-bar"></span>
-                        <span className="icon-bar"></span>
-                        <span className="icon-bar"></span>
-                    </button>
-                    <Link className="navbar-brand" to="/" replace>KeePass 4 Web</Link>
-                    {timer}
-                </div>
-                <div className="collapse navbar-collapse" id="navbar-collapse-1">
-                    {search}
-                    {saveBtn}
-                    <ul className="nav navbar-nav navbar-right">
-                        <li className="dropdown">
-                            <a href="" className="dropdown-toggle" data-toggle="dropdown" role="button"
-                               aria-haspopup="true" aria-expanded="false">
-                                {cn}
-                                <span className="caret"></span>
-                            </a>
-                            {dropdown}
-                        </li>
-                    </ul>
+            <nav className="kp-nav">
+                {sidebarToggle}
+
+                <Link className="kp-nav-brand" to="/" replace>
+                    <IconShield size={20}/>
+                    KeePass 4 Web
+                </Link>
+
+                {cn && isVault && (
+                    <span className="kp-nav-status">
+                        Vault unlocked
+                    </span>
+                )}
+
+                {search}
+                {timer}
+
+                <div className="kp-nav-spacer"/>
+
+                <button
+                    className="kp-theme-toggle"
+                    onClick={this.toggleTheme.bind(this)}
+                    title={this.state.theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                >
+                    {this.state.theme === 'dark' ? <IconSun size={15}/> : <IconMoon size={15}/>}
+                </button>
+
+                <div className="kp-nav-actions">
+                    {this.props.onSaveDb && (
+                        <button
+                            className="kp-btn kp-btn-ghost"
+                            onClick={this.props.onSaveDb}
+                            title="Sync / refresh"
+                        >
+                            <IconSync size={14}/>
+                            Sync
+                        </button>
+                    )}
+
+                    <div className={`kp-dropdown${this.state.dropdownOpen ? ' open' : ''}`}>
+                        <button
+                            className="kp-btn kp-btn-ghost"
+                            onClick={() => this.setState(p => ({ dropdownOpen: !p.dropdownOpen }))}
+                        >
+                            <IconUser size={14}/>
+                            {cn}
+                            <IconChevDown size={10}/>
+                        </button>
+                        <div className="kp-dropdown-menu">
+                            <button className="kp-dropdown-item" onClick={this.onLogout}>
+                                Logout
+                            </button>
+                            <div className="kp-dropdown-divider"/>
+                            <button
+                                className="kp-dropdown-item danger"
+                                onClick={this.onCloseDB}
+                                style={isVault ? {} : { display: 'none' }}
+                            >
+                                Close Vault
+                            </button>
+                        </div>
+                    </div>
+
+                    {this.props.onSaveDb && (
+                        <button
+                            className="kp-btn kp-btn-primary"
+                            onClick={this.props.onSaveDb}
+                        >
+                            <IconSave size={14}/>
+                            Save
+                        </button>
+                    )}
                 </div>
             </nav>
         )

--- a/js/scripts/NodeViewer.js
+++ b/js/scripts/NodeViewer.js
@@ -1,360 +1,304 @@
 import React from 'react'
-import Classnames from 'classnames'
-
 import withNavigateHook from './nagivateHook'
-
+import {
+    IconEye, IconEyeOff, IconCopy, IconDownload, IconCheck, IconPencil,
+} from './Icons'
 
 class NodeViewer extends React.Component {
     constructor(props) {
         super(props)
-        this.setHide = this.setHide.bind(this)
-    }
-
-    showTooltip(btn, message) {
-        $(btn).tooltip('hide')
-            .attr('data-original-title', message)
-            .tooltip('show')
-        setTimeout(function () {
-            $(btn).tooltip('destroy');
-        }, 1000);
-    }
-
-    setHide(target, hide, name, data) {
-        let entry = this.props.entry
-        if (!entry) return
-        // TODO: Handle empty passwords
-        // These are currently kept as ***** without indication to the user
-        if (typeof data === 'undefined')
-            data = null
-        if (!name || name === 'password')
-            entry.password = data
-        else if (entry.strings)
-            entry.strings[name] = data
-
-        if (hide === true)
-            target.childNodes[0].className = 'glyphicon glyphicon-eye-open'
-        else
-            target.childNodes[0].className = 'glyphicon glyphicon-eye-close'
-
-        this.forceUpdate()
-    }
-
-    PWHandler(name, event) {
-        let target = event.currentTarget
-        if (target.childNodes[0].className === 'glyphicon glyphicon-eye-close') {
-            this.setHide(target, true, name)
-            return
+        this.state = {
+            revealed: {},  // field name → revealed plaintext
+            copied:   null, // field name showing copy confirmation
         }
-
-        // else true:
-        event.persist()
-        this.serverRequest = KeePass4Web.fetch('get_protected', {
-            method: 'GET',
-            data: {
-                entry_id: this.props.entry.id,
-                name: name
-            },
-            success: function (data) {
-                this.setHide(target, false, name, data)
-
-                // hide password after X seconds
-                setTimeout(this.PWTimeout.bind(this, target, name), this.props.timeoutSec)
-            }.bind(this),
-            error: KeePass4Web.error.bind(this),
-        })
-
-    }
-
-    copyHandler(value, event) {
-        let btn = event.currentTarget
-        if (value == null)
-            value = ''
-        navigator.clipboard.writeText(value).then(function () {
-            this.showTooltip(btn, 'Copied')
-        }.bind(this))
-            .catch(function () {
-                this.showTooltip(btn, 'Failed to copy')
-            }.bind(this))
-    }
-
-    copyPWHandler(name, event) {
-        event.persist()
-        let target = event.currentTarget.previousSibling
-
-        this.serverRequest = KeePass4Web.fetch('get_protected', {
-            method: 'GET',
-            data: {
-                entry_id: this.props.entry.id,
-                name: name
-            },
-            success: function (data) {
-                this.copyHandler(data, event)
-            }.bind(this),
-            error: KeePass4Web.error.bind(this),
-        })
-        this.setHide(target, true, name)
-    }
-
-    downloadHandler(filename, event) {
-        // mostly taken from http://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post
-        // with adjustments
-        let xhr = new XMLHttpRequest()
-        xhr.open('GET', 'get_file', true)
-        xhr.responseType = 'arraybuffer'
-        xhr.setRequestHeader('X-CSRF-Token', KeePass4Web.getCSRFToken())
-        xhr.onload = function () {
-            if (this.status === 200) {
-                let filename = ""
-                let disposition = xhr.getResponseHeader('Content-Disposition')
-                if (disposition && disposition.indexOf('attachment') !== -1) {
-                    let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
-                    let matches = filenameRegex.exec(disposition)
-                    if (matches != null && matches[1]) {
-                        filename = decodeURIComponent(matches[1].replace(/['"]/g, '').replace(/^UTF-8/i, ''))
-                    }
-                }
-                let type = xhr.getResponseHeader('Content-Type')
-
-                let blob = new Blob([this.response], {type: type})
-                if (typeof window.navigator.msSaveBlob !== 'undefined') {
-                    window.navigator.msSaveBlob(blob, filename)
-                } else {
-                    let URL = window.URL || window.webkitURL
-                    let downloadUrl = URL.createObjectURL(blob)
-
-                    if (filename) {
-                        let a = document.createElement("a")
-                        if (typeof a.download === 'undefined') {
-                            window.location = downloadUrl
-                        } else {
-                            a.href = downloadUrl
-                            a.download = filename
-                            document.body.appendChild(a)
-                            a.click()
-                        }
-                    } else {
-                        window.location = downloadUrl
-                    }
-
-                    setTimeout(function () {
-                        URL.revokeObjectURL(downloadUrl)
-                    }, 100)
-                }
-            } else if (this.status >= 400) {
-                KeePass4Web.error(xhr, null, xhr.responseText)
-            }
-        }
-        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8')
-        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
-
-        KeePass4Web.restartTimer(true)
-
-        xhr.send('id=' + encodeURIComponent(this.props.entry.id) + '&filename=' + encodeURIComponent(filename))
-    }
-
-    PWTimeout(target, name) {
-        // ignore hidden passwords
-        if (target.textContent === true) return
-        this.setHide(target, true, name)
+        this._hideTimers = {}
+        this._copyTimer  = null
     }
 
     componentWillUnmount() {
-        if (this.serverRequest)
-            this.serverRequest.abort()
+        if (this.serverRequest) this.serverRequest.abort()
+        Object.values(this._hideTimers).forEach(clearTimeout)
+        clearTimeout(this._copyTimer)
+    }
+
+    // ── Protected field reveal / hide ─────────────────────────────
+
+    revealField(name) {
+        this.serverRequest = KeePass4Web.fetch('get_protected', {
+            method: 'GET',
+            data: { entry_id: this.props.entry.id, name },
+            success: (data) => {
+                this.setState(prev => ({ revealed: { ...prev.revealed, [name]: data ?? '' } }))
+                clearTimeout(this._hideTimers[name])
+                this._hideTimers[name] = setTimeout(
+                    () => this.hideField(name),
+                    this.props.timeoutSec || 30000,
+                )
+            },
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    hideField(name) {
+        this.setState(prev => {
+            const r = { ...prev.revealed }
+            delete r[name]
+            return { revealed: r }
+        })
+    }
+
+    toggleField(name) {
+        if (Object.prototype.hasOwnProperty.call(this.state.revealed, name)) {
+            this.hideField(name)
+        } else {
+            this.revealField(name)
+        }
+    }
+
+    // ── Copy helpers ──────────────────────────────────────────────
+
+    copyValue(value, name) {
+        if (value == null) value = ''
+        navigator.clipboard.writeText(value)
+            .then(() => {
+                this.setState({ copied: name })
+                clearTimeout(this._copyTimer)
+                this._copyTimer = setTimeout(() => this.setState({ copied: null }), 1500)
+            })
+            .catch(() => {})
+    }
+
+    copyProtected(name) {
+        this.serverRequest = KeePass4Web.fetch('get_protected', {
+            method: 'GET',
+            data: { entry_id: this.props.entry.id, name },
+            success: (data) => this.copyValue(data, name),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    // ── File download ─────────────────────────────────────────────
+
+    downloadFile(filename) {
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', 'get_file', true)
+        xhr.responseType = 'arraybuffer'
+        xhr.setRequestHeader('X-CSRF-Token', KeePass4Web.getCSRFToken())
+        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8')
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+        xhr.onload = function () {
+            if (xhr.status === 200) {
+                let name = ''
+                const disp = xhr.getResponseHeader('Content-Disposition')
+                if (disp && disp.indexOf('attachment') !== -1) {
+                    const m = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disp)
+                    if (m && m[1]) name = decodeURIComponent(m[1].replace(/['"]/g, '').replace(/^UTF-8/i, ''))
+                }
+                const type = xhr.getResponseHeader('Content-Type')
+                const blob = new Blob([xhr.response], { type })
+                const URL  = window.URL || window.webkitURL
+                const url  = URL.createObjectURL(blob)
+                if (name) {
+                    const a  = document.createElement('a')
+                    a.href   = url
+                    a.download = name
+                    document.body.appendChild(a)
+                    a.click()
+                    document.body.removeChild(a)
+                } else {
+                    window.location = url
+                }
+                setTimeout(() => URL.revokeObjectURL(url), 100)
+            } else if (xhr.status >= 400) {
+                KeePass4Web.error(xhr, null, xhr.responseText)
+            }
+        }
+        KeePass4Web.restartTimer(true)
+        xhr.send('id=' + encodeURIComponent(this.props.entry.id) + '&filename=' + encodeURIComponent(filename))
+    }
+
+    // ── Render helpers ────────────────────────────────────────────
+
+    renderCopyBtn(value, name) {
+        const isCopied = this.state.copied === name
+        return (
+            <button
+                className="kp-btn-icon"
+                title={isCopied ? 'Copied!' : 'Copy'}
+                onClick={() => this.copyValue(value, name)}
+            >
+                {isCopied ? <IconCheck size={13}/> : <IconCopy size={13}/>}
+            </button>
+        )
+    }
+
+    renderProtectedField(label, name) {
+        const { revealed, copied } = this.state
+        const isRevealed = Object.prototype.hasOwnProperty.call(revealed, name)
+        const display    = isRevealed ? (revealed[name] || '(empty)') : '••••••••'
+
+        return (
+            <div className="kp-node-field" key={name}>
+                <span className="kp-node-field-label">{label}</span>
+                <span className={`kp-node-field-value${isRevealed ? '' : ' protected'}`}>
+                    {display}
+                </span>
+                <span className="kp-node-field-actions">
+                    <button
+                        className="kp-btn-icon"
+                        title={isRevealed ? 'Hide' : 'Show'}
+                        onClick={() => this.toggleField(name)}
+                    >
+                        {isRevealed ? <IconEyeOff size={13}/> : <IconEye size={13}/>}
+                    </button>
+                    <button
+                        className="kp-btn-icon"
+                        title={copied === name ? 'Copied!' : 'Copy'}
+                        onClick={() => this.copyProtected(name)}
+                    >
+                        {copied === name ? <IconCheck size={13}/> : <IconCopy size={13}/>}
+                    </button>
+                </span>
+            </div>
+        )
     }
 
     render() {
-        let classes = Classnames({
-            'panel': true,
-            'panel-default': true,
-            'loading-mask': this.props.mask,
-        })
+        const { entry, mask } = this.props
 
-        if (!this.props.entry) return (<div className={classes}></div>)
-
-        let entry = this.props.entry
-
-        let fields = []
-        let strings = entry.strings
-        if (strings) {
-            fields.push(
-                <tr key="fields-header">
-                    <th className="kp-fields" colSpan="3">Fields</th>
-                </tr>
-            )
-        }
-        for (let string in strings) {
-            if (strings.hasOwnProperty(string)) {
-                fields.push(
-                    <tr key={string}>
-                        <td className="kp-wrap">{string}</td>
-                        <td className="kp-wrap">
-                            {
-                                entry.protected && entry.protected.hasOwnProperty(string) ?
-                                    (strings[string] == null ? '******' : strings[string])
-                                    : strings[string]
-                            }
-                        </td>
-                        {entry.protected && entry.protected.hasOwnProperty(string) ?
-                            <td>
-                                <div className="btn-group" role="group">
-                                    <button
-                                        onClick={this.PWHandler.bind(this, string)}
-                                        type="button"
-                                        className="btn btn-default btn-sm"
-                                    >
-                                        <span className="glyphicon glyphicon-eye-open"></span>
-                                    </button>
-                                    <button
-                                        onClick={this.copyPWHandler.bind(this, string)}
-                                        type="button"
-                                        className="btn btn-default btn-sm"
-                                    >
-                                        <span className="glyphicon glyphicon-copy"></span>
-                                    </button>
-                                </div>
-                            </td>
-                            : <td></td>}
-                    </tr>
-                )
-            }
-        }
-
-        let files = []
-        let binary = entry.binary
-        if (binary) {
-            files.push(
-                <tr key="files-header">
-                    <th className="kp-files" colSpan="3">Files</th>
-                </tr>
-            )
-        }
-        for (let file in binary) {
-            if (binary.hasOwnProperty(file)) {
-                files.push(
-                    <tr key={file}>
-                        <td colSpan="2" className="kp-wrap">
-                            {file}
-                        </td>
-                        <td>
-                            <button
-                                onClick={this.downloadHandler.bind(this, file)}
-                                type="button"
-                                className="btn btn-default btn-sm"
-                            >
-                                <span className="glyphicon glyphicon-download-alt"></span>
-                            </button>
-                        </td>
-                    </tr>
-                )
-            }
-        }
-
+        if (!entry) return <div className={`kp-detail-content${mask ? ' kp-loading' : ''}`}/>
 
         let icon = null
-        if (entry.custom_icon_uuid)
-            icon = <img className="kp-icon" src={'api/v1/icon/' + encodeURIComponent(entry.custom_icon_uuid)}/>
-        else if (entry.icon)
-            icon = <img className="kp-icon" src={'assets/img/icons/' + encodeURIComponent(entry.icon) + '.png'}/>
+        if (entry.custom_icon_uuid) {
+            icon = <img style={{ width: 36, height: 36, objectFit: 'contain', borderRadius: 8 }}
+                        src={'api/v1/icon/' + encodeURIComponent(entry.custom_icon_uuid)} alt=""/>
+        } else if (entry.icon) {
+            icon = <img style={{ width: 36, height: 36, objectFit: 'contain', borderRadius: 8 }}
+                        src={'assets/img/icons/' + encodeURIComponent(entry.icon) + '.png'} alt=""/>
+        }
 
-        let tags = []
-        for (let tag in entry.tags) {
-            tags.push(
-                <span key={tag} className="kp-wrap badge badge-pill badge-light">{entry.tags[tag]}</span>
+        const tags = (entry.tags || []).map(t => (
+            <span key={t} className="kp-badge">{t}</span>
+        ))
+
+        const extraFields = []
+        const strings = entry.strings || {}
+        for (const name of Object.keys(strings)) {
+            if (entry.protected && Object.prototype.hasOwnProperty.call(entry.protected, name)) {
+                extraFields.push(this.renderProtectedField(name, name))
+            } else {
+                extraFields.push(
+                    <div className="kp-node-field" key={name}>
+                        <span className="kp-node-field-label">{name}</span>
+                        <span className="kp-node-field-value">{strings[name]}</span>
+                        <span className="kp-node-field-actions">
+                            {this.renderCopyBtn(strings[name], name)}
+                        </span>
+                    </div>
+                )
+            }
+        }
+
+        const files = []
+        for (const fname of Object.keys(entry.binary || {})) {
+            files.push(
+                <div className="kp-node-field" key={fname}>
+                    <span className="kp-node-field-label">File</span>
+                    <span className="kp-node-field-value">{fname}</span>
+                    <span className="kp-node-field-actions">
+                        <button
+                            className="kp-btn-icon"
+                            title="Download"
+                            onClick={() => this.downloadFile(fname)}
+                        >
+                            <IconDownload size={13}/>
+                        </button>
+                    </span>
+                </div>
             )
         }
 
         return (
-            <div className={classes}>
-                <div className="panel-heading">
-                    {icon}
-                    {entry.title}
+            <div className={`kp-detail-content${mask ? ' kp-loading' : ''}`}>
+                <div className="kp-detail-header">
+                    <h3>Entry Details</h3>
+                    {this.props.onEdit && (
+                        <button className="kp-btn kp-btn-ghost kp-btn-sm" onClick={this.props.onEdit}>
+                            <IconPencil size={13}/> Edit
+                        </button>
+                    )}
                 </div>
-                <div className="panel-body">
-                    <table className="table table-hover table-condensed kp-table">
-                        <colgroup>
-                            <col className="kp-entry-label"/>
-                            <col className="kp-entry-value"/>
-                            <col className="kp-entry-buttons"/>
-                        </colgroup>
-                        <tbody>
-                        <tr>
-                            <td className="kp-wrap">
-                                Username
-                            </td>
-                            <td className="kp-wrap">
-                                {entry.username}
-                            </td>
-                            <td>
-                                <button
-                                    onClick={this.copyHandler.bind(this, entry.username)}
-                                    type="button"
-                                    className="btn btn-default btn-sm"
-                                >
-                                    <span className="glyphicon glyphicon-copy"></span>
-                                </button>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td className="kp-wrap">
-                                Password
-                            </td>
-                            <td className="kp-wrap">
-                                {entry.password == null ? '******' : entry.password}
-                            </td>
-                            <td>
-                                <div className="btn-group" role="group">
-                                    <button
-                                        onClick={this.PWHandler.bind(this, 'password')}
-                                        type="button"
-                                        className="btn btn-default btn-sm"
-                                    >
-                                        <span className="glyphicon glyphicon-eye-open"></span>
-                                    </button>
-                                    <button
-                                        onClick={this.copyPWHandler.bind(this, 'password')}
-                                        type="button"
-                                        className="btn btn-default btn-sm"
-                                    >
-                                        <span className="glyphicon glyphicon-copy"></span>
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                URL
-                            </td>
-                            <td className="kp-wrap">
+
+                <div className="kp-detail-entry-meta">
+                    <div className="kp-detail-icon">
+                        {icon || <span style={{ fontSize: 28 }}>🔑</span>}
+                    </div>
+                    <div className="kp-detail-icon-info">
+                        <h4>{entry.title}</h4>
+                        {entry.url && (
+                            <p>
                                 <a href={entry.url} target="_blank" rel="noopener noreferrer">{entry.url}</a>
-                            </td>
-                            <td>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td className="kp-wrap">
-                                Notes
-                            </td>
-                            <td className="kp-wrap-comment">
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                <div className="kp-node-fields">
+                    <div className="kp-node-field">
+                        <span className="kp-node-field-label">Username</span>
+                        <span className="kp-node-field-value">{entry.username || '—'}</span>
+                        <span className="kp-node-field-actions">
+                            {this.renderCopyBtn(entry.username, 'username')}
+                        </span>
+                    </div>
+
+                    {this.renderProtectedField('Password', 'password')}
+
+                    {entry.url && (
+                        <div className="kp-node-field">
+                            <span className="kp-node-field-label">URL</span>
+                            <span className="kp-node-field-value">
+                                <a href={entry.url} target="_blank" rel="noopener noreferrer">{entry.url}</a>
+                            </span>
+                            <span className="kp-node-field-actions">
+                                {this.renderCopyBtn(entry.url, 'url')}
+                            </span>
+                        </div>
+                    )}
+
+                    {entry.notes && (
+                        <div className="kp-node-field" style={{ alignItems: 'flex-start' }}>
+                            <span className="kp-node-field-label">Notes</span>
+                            <span className="kp-node-field-value" style={{ whiteSpace: 'pre-wrap' }}>
                                 {entry.notes}
-                            </td>
-                            <td>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td className="kp-wrap">
-                                Tags
-                            </td>
-                            <td className="kp-wrap">
+                            </span>
+                            <span className="kp-node-field-actions"/>
+                        </div>
+                    )}
+
+                    {tags.length > 0 && (
+                        <div className="kp-node-field">
+                            <span className="kp-node-field-label">Tags</span>
+                            <span className="kp-node-field-value" style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                                 {tags}
-                            </td>
-                            <td>
-                            </td>
-                        </tr>
-                        {fields}
-                        {files}
-                        </tbody>
-                    </table>
+                            </span>
+                            <span className="kp-node-field-actions"/>
+                        </div>
+                    )}
+
+                    {extraFields.length > 0 && (
+                        <>
+                            <div className="kp-node-section-label">Custom Fields</div>
+                            {extraFields}
+                        </>
+                    )}
+
+                    {files.length > 0 && (
+                        <>
+                            <div className="kp-node-section-label">Attachments</div>
+                            {files}
+                        </>
+                    )}
                 </div>
             </div>
         )

--- a/js/scripts/TreeNode.js
+++ b/js/scripts/TreeNode.js
@@ -1,113 +1,93 @@
 import React from 'react'
 import withNavigateHook from './nagivateHook'
-
+import { IconFolder, IconChevDown, IconChevRight } from './Icons'
 
 class TreeNode extends React.Component {
     constructor(props) {
         super(props)
-
-        let node = props.node
         this.state = {
-            expanded: node.hasOwnProperty('expanded') ?
-                node.expanded :
-                props.level < (props.options.levels || 3) ? true : false
+            expanded: props.node.expanded !== undefined
+                ? props.node.expanded
+                : props.level < (props.options.levels || 3),
         }
     }
 
-    toggleExpanded(event) {
-        this.setState({expanded: !this.state.expanded})
-        event.stopPropagation()
+    toggle(e) {
+        this.setState(p => ({ expanded: !p.expanded }))
+        e.stopPropagation()
     }
 
-    select(node, event) {
-        let nodeClick = this.props.options.nodeClick
-        if (nodeClick)
-            nodeClick(node)
-        event.stopPropagation()
+    select(node, e) {
+        e.stopPropagation()
+        const { nodeClick } = this.props.options
+        if (nodeClick) nodeClick(node)
     }
 
     render() {
-        let node = this.props.node
-        let options = this.props.options
-        let showBorder = typeof options.showBorder === 'undefined' ? true : options.showBorder
+        const { node, level, visible, options } = this.props
+        const { expanded } = this.state
 
-        let style
-        if (!this.props.visible) {
-            style = {
-                display: 'none'
-            }
+        if (!visible) return null
+
+        const hasChildren = node.children && node.children.length > 0
+
+        let expandIcon = null
+        if (hasChildren) {
+            expandIcon = (
+                <span
+                    className="kp-tree-expand"
+                    onClick={this.toggle.bind(this)}
+                    style={{ display: 'flex', cursor: 'pointer', flexShrink: 0 }}
+                >
+                    {expanded ? <IconChevDown size={12}/> : <IconChevRight size={12}/>}
+                </span>
+            )
         } else {
-            if (!showBorder) {
-                style.border = 'none'
-            } else if (options.borderColor) {
-                style.border = '1px solid ' + options.borderColor
-            }
+            expandIcon = <span style={{ width: 12, flexShrink: 0 }}/>
         }
 
-        let indents = []
-        for (let i = 0; i < this.props.level - 1; i++) {
-            indents.push(<span className="indent" key={i}></span>)
-        }
-
-        let expandCollapseIcon
-        if (node.children) {
-            if (!this.state.expanded) {
-                expandCollapseIcon = (
-                    <span className={options.expandIcon || 'glyphicon glyphicon-plus'}
-                          onClick={this.toggleExpanded.bind(this)}>
-                    </span>
-                )
-            } else {
-                expandCollapseIcon = (
-                    <span className={options.collapseIcon || 'glyphicon glyphicon-minus'}
-                          onClick={this.toggleExpanded.bind(this)}>
-                    </span>
-                )
-            }
+        let nodeIcon = null
+        if (node.custom_icon_uuid) {
+            nodeIcon = (
+                <img
+                    style={{ width: 15, height: 15, objectFit: 'contain', flexShrink: 0 }}
+                    src={'api/v1/icon/' + encodeURIComponent(node.custom_icon_uuid)}
+                    alt=""
+                />
+            )
         } else {
-            expandCollapseIcon = (
-                <span className={options.emptyIcon || 'glyphicon glyphicon-none'}></span>
+            nodeIcon = (
+                <span className="kp-tree-icon" style={{ display: 'flex' }}>
+                    <IconFolder size={15}/>
+                </span>
             )
         }
 
-        let srcurl
-        if (node.custom_icon_uuid) {
-            srcurl = 'api/v1/icon/' + encodeURIComponent(node.custom_icon_uuid)
-        } else {
-            srcurl = 'assets/img/icons/' + encodeURIComponent(node.icon || options.nodeIcon || '48') + '.png'
-        }
-        let nodeIcon = (
-            <img src={srcurl} className="kp-icon icon"/>
-        )
-
-        let children = []
-        if (node.children) {
-            let nodes = node.children
-            for (let i in nodes) {
-                children.push(
-                    <TreeNode
-                        node={nodes[i]}
-                        level={this.props.level + 1}
-                        visible={this.state.expanded && this.props.visible}
-                        options={options}
-                        key={nodes[i].id}
-                    />
-                )
-            }
-        }
+        const children = hasChildren ? node.children.map(child => (
+            <TreeNode
+                node={child}
+                level={level + 1}
+                visible={expanded}
+                options={options}
+                key={child.id}
+            />
+        )) : null
 
         return (
             <div>
-                <li className="list-group-item"
-                    style={style}
+                <div
+                    className="kp-tree-item"
                     onClick={this.select.bind(this, node)}
                 >
-                    {indents}
-                    {expandCollapseIcon}
+                    {expandIcon}
                     {nodeIcon}
                     {node.title}
-                </li>
-                {children}
+                </div>
+                {children && (
+                    <div className="kp-tree-children">
+                        {children}
+                    </div>
+                )}
             </div>
         )
     }

--- a/js/scripts/TreeViewer.js
+++ b/js/scripts/TreeViewer.js
@@ -1,54 +1,61 @@
 import React from 'react'
 import TreeNode from './TreeNode'
-
 import withNavigateHook from './nagivateHook'
-
+import { IconFolderRoot, IconPlus } from './Icons'
 
 class TreeViewer extends React.Component {
     render() {
-        var root = this.props.tree || {}
-        var tree = root.children
+        const root  = this.props.tree || {}
+        const nodes = root.children || []
 
-        var children = []
-        for (var i in tree) {
-            children.push(
-                <TreeNode
-                    node={tree[i]}
-                    level={1}
-                    visible={true}
-                    options={this.props}
-                    key={tree[i].id}
-                />
-            )
-        }
+        const children = nodes.map(n => (
+            <TreeNode
+                node={n}
+                level={1}
+                visible
+                options={this.props}
+                key={n.id}
+            />
+        ))
 
-        var srcurl
-        if (root.custom_icon_uuid) {
-            srcurl = 'api/v1/icon/' + encodeURIComponent(root.custom_icon_uuid)
-        } else {
-            srcurl = 'assets/img/icons/' + encodeURIComponent(root.icon || this.props.nodeIcon || '49') + '.png'
-        }
-        var nodeIcon = (
-            <img src={srcurl} className="kp-icon icon"/>
-        )
+        const folderCount = nodes.filter(n => n.children !== undefined).length || nodes.length
 
         return (
-            <div className="panel panel-default">
-                <div
-                    className="treeview-header panel-heading"
-                    onClick={this.props.nodeClick.bind(this, root)}
-                >
-                    {nodeIcon}
-                    {root.title}
+            <aside className={`kp-sidebar${this.props.open ? ' open' : ''}`} id="kp-sidebar">
+                <div className="kp-sidebar-header">
+                    <div>
+                        <div className="kp-sidebar-label">Groups</div>
+                        <div className="kp-sidebar-count">{folderCount} folder{folderCount !== 1 ? 's' : ''}</div>
+                    </div>
+                    {this.props.onAddRootGroup && (
+                        <button
+                            className="kp-sidebar-add"
+                            title="Add group to root"
+                            onClick={this.props.onAddRootGroup}
+                        >
+                            <IconPlus size={13}/>
+                        </button>
+                    )}
                 </div>
 
-                <ul className="treeview-body list-group">
-                    {children}
-                </ul>
-            </div>
+                <div className="kp-tree">
+                    {/* Root row */}
+                    <div
+                        className="kp-tree-item"
+                        onClick={() => this.props.nodeClick && this.props.nodeClick(root)}
+                    >
+                        <span style={{ width: 12, flexShrink: 0 }}/>
+                        <IconFolderRoot size={15}/>
+                        {root.title || 'Root'}
+                    </div>
+
+                    <div className="kp-tree-children">
+                        {children}
+                    </div>
+                </div>
+            </aside>
         )
     }
 }
-
 
 export default withNavigateHook(TreeViewer)

--- a/js/scripts/Viewport.js
+++ b/js/scripts/Viewport.js
@@ -1,33 +1,45 @@
 import React from 'react'
 import NodeViewer from './NodeViewer'
 import GroupViewer from './GroupViewer'
+import EntryForm from './EntryForm'
 import NavBar from './NavBar'
 import TreeViewer from './TreeViewer'
 import withNavigateHook from './nagivateHook'
-
+import { IconSave, IconX } from './Icons'
 
 class Viewport extends React.Component {
     constructor(props) {
         super(props)
-        this.onGroupSelect = this.onGroupSelect.bind(this)
-        this.onSelect = this.onSelect.bind(this)
-        this.onSearch = this.onSearch.bind(this)
-        this.onEntryCreated = this.onEntryCreated.bind(this)
-        this.onDeleteEntry = this.onDeleteEntry.bind(this)
-        this.onSaveDb = this.onSaveDb.bind(this)
+        this.onGroupSelect  = this.onGroupSelect.bind(this)
+        this.onSelect       = this.onSelect.bind(this)
+        this.onSearch       = this.onSearch.bind(this)
         this.onGroupRenamed = this.onGroupRenamed.bind(this)
         this.onGroupCreated = this.onGroupCreated.bind(this)
+        this.onNewEntry     = this.onNewEntry.bind(this)
+        this.onEditEntry    = this.onEditEntry.bind(this)
+        this.onFormSaved    = this.onFormSaved.bind(this)
+        this.onFormCancel   = this.onFormCancel.bind(this)
+        this.onEntryDeleted = this.onEntryDeleted.bind(this)
+        this.onAddRootGroup = this.onAddRootGroup.bind(this)
+        this.onSaveDb       = this.onSaveDb.bind(this)
+        this.toggleSidebar  = this.toggleSidebar.bind(this)
 
         this.state = {
-            tree: {},
-            entry: null,
-            group: null,
-            groupDepth: 0,
-            saveModal: false,
+            tree:         {},
+            group:        null,
+            groupDepth:   0,
+            groupMask:    false,
+            rightPanel:   { mode: 'none', entry: null },
+            nodeMask:     false,
+            sidebarOpen:  false,
+            // save-db modal
+            saveModal:    false,
             savePassword: '',
-            saveStatus: '',
+            saveStatus:   '',
         }
     }
+
+    // ── Tree helpers ──────────────────────────────────────────────
 
     findGroupDepth(group, targetId, depth = 0) {
         if (group.id === targetId) return depth
@@ -38,89 +50,64 @@ class Viewport extends React.Component {
         return -1
     }
 
-    scroll(id) {
-        document.getElementById(id).scrollIntoView()
-        if (window.scrollY)
-            window.scroll(0, scrollY - 70)
-    }
+    // ── Group selection ───────────────────────────────────────────
 
     onGroupSelect(group) {
         if (!group || !group.id) return
-        if (this.state.group && this.state.group.id && group.id === this.state.group.id) return
+        if (this.state.group && this.state.group.id === group.id) return
 
-        if (this.serverRequest)
-            this.serverRequest.abort()
+        if (this.serverRequest) this.serverRequest.abort()
 
         const depth = this.findGroupDepth(this.state.tree, group.id)
-        this.setState({ entry: null, groupMask: true, groupDepth: depth >= 0 ? depth : 0 })
+        this.setState({
+            groupMask:  true,
+            groupDepth: depth >= 0 ? depth : 0,
+            rightPanel: { mode: 'none', entry: null },
+            sidebarOpen: false,
+        })
 
         this.serverRequest = KeePass4Web.fetch('get_group_entries', {
             method: 'GET',
             data: { id: group.id },
-            success: (data) => {
-                this.setState({ group: data })
-                this.scroll('group-viewer')
-            },
+            success: (data) => this.setState({ group: data }),
             error: KeePass4Web.error.bind(this),
             complete: () => this.setState({ groupMask: false }),
         })
     }
 
+    // ── Entry selection (view detail) ─────────────────────────────
+
     onSelect(entry) {
         if (!entry || !entry.id) return
-        if (this.state.entry && this.state.entry.id && entry.id === this.state.entry.id) return
+        if (this.serverRequest) this.serverRequest.abort()
 
-        if (this.serverRequest)
-            this.serverRequest.abort()
+        this.setState({ nodeMask: true, rightPanel: { mode: 'view', entry: null } })
 
-        this.setState({ nodeMask: true })
         this.serverRequest = KeePass4Web.fetch('get_entry', {
             method: 'GET',
             data: { id: entry.id },
-            success: (data) => {
-                this.setState({ entry: null })
-                this.setState({ entry: data })
-                this.scroll('node-viewer')
-            },
+            success: (data) => this.setState({ rightPanel: { mode: 'view', entry: data } }),
             error: KeePass4Web.error.bind(this),
             complete: () => this.setState({ nodeMask: false }),
         })
     }
 
+    // ── Search ───────────────────────────────────────────────────
+
     onSearch(refs, event) {
         event.preventDefault()
-
-        if (this.serverRequest)
-            this.serverRequest.abort()
-
-        this.setState({ entry: null, groupMask: true })
-
+        if (this.serverRequest) this.serverRequest.abort()
+        this.setState({ groupMask: true, rightPanel: { mode: 'none', entry: null } })
         this.serverRequest = KeePass4Web.fetch('search_entries', {
             method: 'GET',
             data: { term: refs.term.value.replace(/^\s+|\s+$/g, '') },
-            success: (data) => {
-                this.setState({ group: data, groupMask: false })
-                this.scroll('group-viewer')
-            },
+            success: (data) => this.setState({ group: data }),
             error: KeePass4Web.error.bind(this),
             complete: () => this.setState({ groupMask: false }),
         })
     }
 
-    // Re-fetch the current group after a write so the entry list updates
-    refreshGroup() {
-        if (!this.state.group || !this.state.group.id) return
-        KeePass4Web.fetch('get_group_entries', {
-            method: 'GET',
-            data: { id: this.state.group.id },
-            success: (data) => this.setState({ group: data, entry: null }),
-            error: KeePass4Web.error.bind(this),
-        })
-    }
-
-    onEntryCreated() {
-        this.refreshGroup()
-    }
+    // ── Group mutations ───────────────────────────────────────────
 
     onGroupCreated() {
         KeePass4Web.fetch('get_groups', {
@@ -131,30 +118,90 @@ class Viewport extends React.Component {
     }
 
     onGroupRenamed(groupId, newTitle) {
-        // Patch the title in the tree without a full reload
         const patchTree = (groups) => groups.map(g => ({
             ...g,
-            title: g.id === groupId ? newTitle : g.title,
+            title:    g.id === groupId ? newTitle : g.title,
             children: g.children ? patchTree(g.children) : g.children,
         }))
         this.setState(prev => ({
-            tree: { ...prev.tree, children: patchTree(prev.tree.children || []) },
+            tree:  { ...prev.tree, children: patchTree(prev.tree.children || []) },
             group: prev.group && prev.group.id === groupId
                 ? { ...prev.group, title: newTitle }
                 : prev.group,
         }))
     }
 
-    onDeleteEntry(entry) {
-        if (!window.confirm(`Delete "${entry.title}"?`)) return
-
-        KeePass4Web.fetch('entry', {
-            method: 'DELETE',
-            data: { id: entry.id },
-            success: () => this.refreshGroup(),
+    onAddRootGroup() {
+        const name = window.prompt('New group name:')
+        if (!name || !name.trim()) return
+        KeePass4Web.fetch('group', {
+            method: 'POST',
+            data: { parent_id: this.state.tree.id, title: name.trim() },
+            success: () => this.onGroupCreated(),
             error: KeePass4Web.error.bind(this),
         })
     }
+
+    // ── Entry mutations ───────────────────────────────────────────
+
+    refreshGroup() {
+        if (!this.state.group || !this.state.group.id) return
+        KeePass4Web.fetch('get_group_entries', {
+            method: 'GET',
+            data: { id: this.state.group.id },
+            success: (data) => this.setState({ group: data }),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onNewEntry() {
+        this.setState({ rightPanel: { mode: 'new', entry: null } })
+    }
+
+    onEditEntry(entry) {
+        if (!entry || !entry.id) return
+        if (this.serverRequest) this.serverRequest.abort()
+        this.setState({ nodeMask: true })
+        this.serverRequest = KeePass4Web.fetch('get_entry', {
+            method: 'GET',
+            data: { id: entry.id },
+            success: (data) => this.setState({ rightPanel: { mode: 'edit', entry: data } }),
+            error: KeePass4Web.error.bind(this),
+            complete: () => this.setState({ nodeMask: false }),
+        })
+    }
+
+    onFormSaved(savedId) {
+        this.refreshGroup()
+        // After saving, switch to view mode for the saved entry
+        if (savedId) {
+            KeePass4Web.fetch('get_entry', {
+                method: 'GET',
+                data: { id: savedId },
+                success: (data) => this.setState({ rightPanel: { mode: 'view', entry: data } }),
+                error: () => this.setState({ rightPanel: { mode: 'none', entry: null } }),
+            })
+        } else {
+            this.setState({ rightPanel: { mode: 'none', entry: null } })
+        }
+    }
+
+    onFormCancel() {
+        const { rightPanel } = this.state
+        // If we were editing, go back to viewing
+        if (rightPanel.mode === 'edit' && rightPanel.entry) {
+            this.setState({ rightPanel: { mode: 'view', entry: rightPanel.entry } })
+        } else {
+            this.setState({ rightPanel: { mode: 'none', entry: null } })
+        }
+    }
+
+    onEntryDeleted() {
+        this.refreshGroup()
+        this.setState({ rightPanel: { mode: 'none', entry: null } })
+    }
+
+    // ── Save DB ───────────────────────────────────────────────────
 
     onSaveDb(e) {
         e.preventDefault()
@@ -163,11 +210,17 @@ class Viewport extends React.Component {
             method: 'POST',
             data: { password: this.state.savePassword },
             success: () => this.setState({ saveModal: false, savePassword: '', saveStatus: '' }),
-            error: (err) => {
-                this.setState({ saveStatus: err.message || 'Save failed' })
-            },
+            error: (err) => this.setState({ saveStatus: (err && (err.msg || err.toString())) || 'Save failed' }),
         })
     }
+
+    // ── Sidebar toggle (mobile) ───────────────────────────────────
+
+    toggleSidebar() {
+        this.setState(prev => ({ sidebarOpen: !prev.sidebarOpen }))
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────
 
     componentDidMount() {
         KeePass4Web.fetch('get_groups', {
@@ -182,82 +235,127 @@ class Viewport extends React.Component {
     }
 
     componentWillUnmount() {
-        if (this.serverRequest)
-            this.serverRequest.abort()
+        if (this.serverRequest) this.serverRequest.abort()
     }
 
     render() {
+        const { tree, group, groupDepth, groupMask, nodeMask, rightPanel, sidebarOpen } = this.state
+
+        const detailOpen = rightPanel.mode !== 'none'
+
         const saveModal = this.state.saveModal ? (
-            <div style={{
-                position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-                background: 'rgba(0,0,0,.5)', zIndex: 1050, display: 'flex',
-                alignItems: 'center', justifyContent: 'center',
-            }}>
-                <div className="panel panel-default" style={{ width: 340, padding: 16 }}>
-                    <div className="panel-heading"><b>Save Database to Disk</b></div>
-                    <div className="panel-body">
-                        <p>Re-enter your master password to write changes to the server file.</p>
-                        <form onSubmit={this.onSaveDb}>
-                            <div className="form-group">
-                                <input
-                                    type="password"
-                                    className="form-control"
-                                    placeholder="Master password"
-                                    autoFocus
-                                    value={this.state.savePassword}
-                                    onChange={e => this.setState({ savePassword: e.target.value, saveStatus: '' })}
-                                />
-                            </div>
-                            {this.state.saveStatus && (
-                                <p className="text-danger">{this.state.saveStatus}</p>
-                            )}
-                            <div className="btn-group">
-                                <button type="submit" className="btn btn-primary">Save</button>
-                                <button type="button" className="btn btn-default"
-                                    onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}>
-                                    Cancel
-                                </button>
-                            </div>
-                        </form>
+            <div className="kp-modal-backdrop" onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}>
+                <div className="kp-modal" onClick={e => e.stopPropagation()}>
+                    <div className="kp-modal-header">
+                        <h3>Save Database</h3>
+                        <button
+                            className="kp-btn-icon"
+                            onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}
+                        >
+                            <IconX size={16}/>
+                        </button>
                     </div>
+                    <p style={{ fontSize: 13, color: 'var(--kp-text-muted)', marginBottom: 16 }}>
+                        Re-enter the <strong>KeePass master password</strong> (not your login password) to write changes to the server file.
+                    </p>
+                    <form onSubmit={this.onSaveDb}>
+                        <div className="kp-field" style={{ marginBottom: 12 }}>
+                            <label>Master password</label>
+                            <input
+                                type="password"
+                                className="kp-input"
+                                placeholder="Master password"
+                                autoFocus
+                                value={this.state.savePassword}
+                                onChange={e => this.setState({ savePassword: e.target.value, saveStatus: '' })}
+                            />
+                        </div>
+                        {this.state.saveStatus && (
+                            <p style={{ color: 'var(--kp-danger)', fontSize: 13, marginBottom: 8 }}>
+                                {this.state.saveStatus}
+                            </p>
+                        )}
+                        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                            <button type="button" className="kp-btn kp-btn-outline"
+                                    onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}>
+                                Cancel
+                            </button>
+                            <button type="submit" className="kp-btn kp-btn-primary">
+                                <IconSave size={13}/>
+                                Save
+                            </button>
+                        </div>
+                    </form>
                 </div>
             </div>
         ) : null
 
         return (
-            <div className="container-fluid">
+            <div className="kp-app">
                 <NavBar
                     showSearch
                     onSearch={this.onSearch}
                     onSaveDb={() => this.setState({ saveModal: true })}
+                    onToggleSidebar={this.toggleSidebar}
                 />
+
                 {saveModal}
-                <div className="row">
-                    <div className="col-sm-2 dir-tree">
-                        <TreeViewer
-                            tree={this.state.tree}
-                            nodeClick={this.onGroupSelect}
-                            nodeIcon="48"
-                        />
-                    </div>
-                    <div id="group-viewer" className="col-sm-4">
-                        <GroupViewer
-                            group={this.state.group}
-                            groupDepth={this.state.groupDepth}
-                            onSelect={this.onSelect}
-                            mask={this.state.groupMask}
-                            onEntryCreated={this.onEntryCreated}
-                            onDeleteEntry={this.onDeleteEntry}
-                            onGroupRenamed={this.onGroupRenamed}
-                            onGroupCreated={this.onGroupCreated}
-                        />
-                    </div>
-                    <div id="node-viewer" className="col-sm-6">
-                        <NodeViewer
-                            entry={this.state.entry}
-                            timeoutSec={30 * 1000}
-                            mask={this.state.nodeMask}
-                        />
+
+                <div className="kp-body">
+                    {/* Mobile sidebar overlay */}
+                    {sidebarOpen && (
+                        <div className="kp-sidebar-overlay" onClick={() => this.setState({ sidebarOpen: false })}/>
+                    )}
+
+                    <TreeViewer
+                        tree={tree}
+                        nodeClick={this.onGroupSelect}
+                        nodeIcon="48"
+                        open={sidebarOpen}
+                        onAddRootGroup={this.onAddRootGroup}
+                    />
+
+                    <GroupViewer
+                        group={group}
+                        groupDepth={groupDepth}
+                        selectedEntryId={rightPanel.entry ? rightPanel.entry.id : null}
+                        onSelect={this.onSelect}
+                        mask={groupMask}
+                        onNewEntry={this.onNewEntry}
+                        onEditEntry={this.onEditEntry}
+                        onEntryDeleted={this.onEntryDeleted}
+                        onGroupRenamed={this.onGroupRenamed}
+                        onGroupCreated={this.onGroupCreated}
+                    />
+
+                    <div className={`kp-detail${detailOpen ? ' open' : ''}`}>
+                        {rightPanel.mode === 'view' && (
+                            <NodeViewer
+                                entry={rightPanel.entry}
+                                timeoutSec={30000}
+                                mask={nodeMask}
+                                onEdit={() => rightPanel.entry && this.onEditEntry(rightPanel.entry)}
+                            />
+                        )}
+                        {(rightPanel.mode === 'new' || rightPanel.mode === 'edit') && (
+                            <EntryForm
+                                mode={rightPanel.mode}
+                                entry={rightPanel.entry}
+                                group={group}
+                                onSaved={this.onFormSaved}
+                                onCancel={this.onFormCancel}
+                            />
+                        )}
+                        {!detailOpen && (
+                            <div style={{
+                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                height: '100%', color: 'var(--kp-text-muted)', fontSize: 13,
+                                flexDirection: 'column', gap: 8,
+                            }}>
+                                <span style={{ fontSize: 32 }}>🔑</span>
+                                Select an entry to view details
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/js/scripts/Viewport.js
+++ b/js/scripts/Viewport.js
@@ -15,15 +15,27 @@ class Viewport extends React.Component {
         this.onEntryCreated = this.onEntryCreated.bind(this)
         this.onDeleteEntry = this.onDeleteEntry.bind(this)
         this.onSaveDb = this.onSaveDb.bind(this)
+        this.onGroupRenamed = this.onGroupRenamed.bind(this)
+        this.onGroupCreated = this.onGroupCreated.bind(this)
 
         this.state = {
             tree: {},
             entry: null,
             group: null,
+            groupDepth: 0,
             saveModal: false,
             savePassword: '',
             saveStatus: '',
         }
+    }
+
+    findGroupDepth(group, targetId, depth = 0) {
+        if (group.id === targetId) return depth
+        for (const child of (group.children || [])) {
+            const d = this.findGroupDepth(child, targetId, depth + 1)
+            if (d >= 0) return d
+        }
+        return -1
     }
 
     scroll(id) {
@@ -39,7 +51,8 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({ entry: null, groupMask: true })
+        const depth = this.findGroupDepth(this.state.tree, group.id)
+        this.setState({ entry: null, groupMask: true, groupDepth: depth >= 0 ? depth : 0 })
 
         this.serverRequest = KeePass4Web.fetch('get_group_entries', {
             method: 'GET',
@@ -107,6 +120,29 @@ class Viewport extends React.Component {
 
     onEntryCreated() {
         this.refreshGroup()
+    }
+
+    onGroupCreated() {
+        KeePass4Web.fetch('get_groups', {
+            method: 'GET',
+            success: (data) => this.setState({ tree: data.groups }),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onGroupRenamed(groupId, newTitle) {
+        // Patch the title in the tree without a full reload
+        const patchTree = (groups) => groups.map(g => ({
+            ...g,
+            title: g.id === groupId ? newTitle : g.title,
+            children: g.children ? patchTree(g.children) : g.children,
+        }))
+        this.setState(prev => ({
+            tree: { ...prev.tree, children: patchTree(prev.tree.children || []) },
+            group: prev.group && prev.group.id === groupId
+                ? { ...prev.group, title: newTitle }
+                : prev.group,
+        }))
     }
 
     onDeleteEntry(entry) {
@@ -207,10 +243,13 @@ class Viewport extends React.Component {
                     <div id="group-viewer" className="col-sm-4">
                         <GroupViewer
                             group={this.state.group}
+                            groupDepth={this.state.groupDepth}
                             onSelect={this.onSelect}
                             mask={this.state.groupMask}
                             onEntryCreated={this.onEntryCreated}
                             onDeleteEntry={this.onDeleteEntry}
+                            onGroupRenamed={this.onGroupRenamed}
+                            onGroupCreated={this.onGroupCreated}
                         />
                     </div>
                     <div id="node-viewer" className="col-sm-6">

--- a/js/scripts/Viewport.js
+++ b/js/scripts/Viewport.js
@@ -12,18 +12,23 @@ class Viewport extends React.Component {
         this.onGroupSelect = this.onGroupSelect.bind(this)
         this.onSelect = this.onSelect.bind(this)
         this.onSearch = this.onSearch.bind(this)
+        this.onEntryCreated = this.onEntryCreated.bind(this)
+        this.onDeleteEntry = this.onDeleteEntry.bind(this)
+        this.onSaveDb = this.onSaveDb.bind(this)
 
         this.state = {
             tree: {},
             entry: null,
             group: null,
+            saveModal: false,
+            savePassword: '',
+            saveStatus: '',
         }
     }
 
     scroll(id) {
         document.getElementById(id).scrollIntoView()
         if (window.scrollY)
-            // scroll height of bootstrap fixed header down
             window.scroll(0, scrollY - 70)
     }
 
@@ -34,66 +39,38 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            entry: null,
-            groupMask: true,
-        })
+        this.setState({ entry: null, groupMask: true })
 
         this.serverRequest = KeePass4Web.fetch('get_group_entries', {
-            method: "GET",
-            data: {
-                id: group.id,
-            },
-            success: function (data) {
-                this.setState({
-                    group: data,
-                })
-
+            method: 'GET',
+            data: { id: group.id },
+            success: (data) => {
+                this.setState({ group: data })
                 this.scroll('group-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    groupMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ groupMask: false }),
         })
     }
 
     onSelect(entry) {
         if (!entry || !entry.id) return
-        // ignore already selected
         if (this.state.entry && this.state.entry.id && entry.id === this.state.entry.id) return
 
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            nodeMask: true,
-        })
+        this.setState({ nodeMask: true })
         this.serverRequest = KeePass4Web.fetch('get_entry', {
-            method: "GET",
-            data: {
-                id: entry.id,
-            },
-            success: function (data) {
-                // remove entry first to rerender entry
-                // important for eye close/open buttons
-                this.setState({
-                    entry: null,
-                })
-                this.setState({
-                    entry: data,
-                })
-
+            method: 'GET',
+            data: { id: entry.id },
+            success: (data) => {
+                this.setState({ entry: null })
+                this.setState({ entry: data })
                 this.scroll('node-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    nodeMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ nodeMask: false }),
         })
     }
 
@@ -103,46 +80,67 @@ class Viewport extends React.Component {
         if (this.serverRequest)
             this.serverRequest.abort()
 
-        this.setState({
-            entry: null,
-            groupMask: true,
-        })
+        this.setState({ entry: null, groupMask: true })
 
         this.serverRequest = KeePass4Web.fetch('search_entries', {
-            method: "GET",
-            data: {
-                term: refs.term.value.replace(/^\s+|\s+$/g, ''),
-            },
-            success: function (data) {
-                this.setState({
-                    group: data,
-                    groupMask: false,
-                })
-
+            method: 'GET',
+            data: { term: refs.term.value.replace(/^\s+|\s+$/g, '') },
+            success: (data) => {
+                this.setState({ group: data, groupMask: false })
                 this.scroll('group-viewer')
-            }.bind(this),
+            },
             error: KeePass4Web.error.bind(this),
-            complete: function () {
-                this.setState({
-                    groupMask: false,
-                })
-            }.bind(this)
+            complete: () => this.setState({ groupMask: false }),
+        })
+    }
+
+    // Re-fetch the current group after a write so the entry list updates
+    refreshGroup() {
+        if (!this.state.group || !this.state.group.id) return
+        KeePass4Web.fetch('get_group_entries', {
+            method: 'GET',
+            data: { id: this.state.group.id },
+            success: (data) => this.setState({ group: data, entry: null }),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onEntryCreated() {
+        this.refreshGroup()
+    }
+
+    onDeleteEntry(entry) {
+        if (!window.confirm(`Delete "${entry.title}"?`)) return
+
+        KeePass4Web.fetch('entry', {
+            method: 'DELETE',
+            data: { id: entry.id },
+            success: () => this.refreshGroup(),
+            error: KeePass4Web.error.bind(this),
+        })
+    }
+
+    onSaveDb(e) {
+        e.preventDefault()
+        this.setState({ saveStatus: 'Saving…' })
+        KeePass4Web.fetch('save_db', {
+            method: 'POST',
+            data: { password: this.state.savePassword },
+            success: () => this.setState({ saveModal: false, savePassword: '', saveStatus: '' }),
+            error: (err) => {
+                this.setState({ saveStatus: err.message || 'Save failed' })
+            },
         })
     }
 
     componentDidMount() {
-        // TODO: add loading mask for the whole viewport while fetching groups
         KeePass4Web.fetch('get_groups', {
-            method: "GET",
-            success: function (data) {
-                this.setState({
-                    tree: data.groups
-                })
+            method: 'GET',
+            success: (data) => {
+                this.setState({ tree: data.groups })
                 if (data.last_selected)
-                    this.onGroupSelect({
-                        id: data.last_selected
-                    })
-            }.bind(this),
+                    this.onGroupSelect({ id: data.last_selected })
+            },
             error: KeePass4Web.error.bind(this),
         })
     }
@@ -153,12 +151,51 @@ class Viewport extends React.Component {
     }
 
     render() {
+        const saveModal = this.state.saveModal ? (
+            <div style={{
+                position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+                background: 'rgba(0,0,0,.5)', zIndex: 1050, display: 'flex',
+                alignItems: 'center', justifyContent: 'center',
+            }}>
+                <div className="panel panel-default" style={{ width: 340, padding: 16 }}>
+                    <div className="panel-heading"><b>Save Database to Disk</b></div>
+                    <div className="panel-body">
+                        <p>Re-enter your master password to write changes to the server file.</p>
+                        <form onSubmit={this.onSaveDb}>
+                            <div className="form-group">
+                                <input
+                                    type="password"
+                                    className="form-control"
+                                    placeholder="Master password"
+                                    autoFocus
+                                    value={this.state.savePassword}
+                                    onChange={e => this.setState({ savePassword: e.target.value, saveStatus: '' })}
+                                />
+                            </div>
+                            {this.state.saveStatus && (
+                                <p className="text-danger">{this.state.saveStatus}</p>
+                            )}
+                            <div className="btn-group">
+                                <button type="submit" className="btn btn-primary">Save</button>
+                                <button type="button" className="btn btn-default"
+                                    onClick={() => this.setState({ saveModal: false, savePassword: '', saveStatus: '' })}>
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        ) : null
+
         return (
             <div className="container-fluid">
                 <NavBar
                     showSearch
                     onSearch={this.onSearch}
+                    onSaveDb={() => this.setState({ saveModal: true })}
                 />
+                {saveModal}
                 <div className="row">
                     <div className="col-sm-2 dir-tree">
                         <TreeViewer
@@ -172,6 +209,8 @@ class Viewport extends React.Component {
                             group={this.state.group}
                             onSelect={this.onSelect}
                             mask={this.state.groupMask}
+                            onEntryCreated={this.onEntryCreated}
+                            onDeleteEntry={this.onDeleteEntry}
                         />
                     </div>
                     <div id="node-viewer" className="col-sm-6">

--- a/js/style/app.css
+++ b/js/style/app.css
@@ -1,4 +1,5 @@
 @import url('node_modules/bootstrap/dist/css/bootstrap.min.css');
+@import url('./vault.css');
 
 body {
     padding-top: 70px;

--- a/js/style/vault.css
+++ b/js/style/vault.css
@@ -1,0 +1,941 @@
+/* ═══════════════════════════════════════════════════════════
+   KeePass 4 Web — Vault UI Design System
+   Flat, modern, responsive. CSS variables for easy theming.
+   ═══════════════════════════════════════════════════════════ */
+
+/* ─── TOKENS ─────────────────────────────────────────────── */
+:root {
+  --kp-bg:             #f4f5f7;
+  --kp-surface:        #ffffff;
+  --kp-surface-hover:  #f8f9fb;
+  --kp-border:         #dfe1e6;
+  --kp-focus:          #4c9aff;
+
+  --kp-primary:        #1b6bde;
+  --kp-primary-dark:   #1558b5;
+  --kp-primary-bg:     #e8f0fd;
+
+  --kp-danger:         #d63638;
+  --kp-danger-dark:    #b32d2f;
+  --kp-danger-bg:      #fff0f0;
+
+  --kp-success:        #0a7c4c;
+  --kp-success-bg:     #e3fcef;
+
+  --kp-warn-bg:        #fffae6;
+  --kp-warn-border:    #f6c000;
+  --kp-warn-text:      #6e4e00;
+
+  --kp-text:           #1a2332;
+  --kp-text-secondary: #5e6c84;
+  --kp-text-muted:     #97a0af;
+
+  --kp-sidebar-bg:     #fafbfc;
+  --kp-sidebar-hover:  #eaecf0;
+  --kp-sidebar-active: #dce8ff;
+  --kp-sidebar-active-text: #1b6bde;
+
+  --kp-nav-h:          52px;
+  --kp-sidebar-w:      224px;
+  --kp-detail-w:       440px;
+
+  --kp-r-sm:  4px;
+  --kp-r:     6px;
+  --kp-r-lg:  10px;
+
+  --kp-shadow-sm: 0 1px 3px rgba(0,0,0,.07);
+  --kp-shadow:    0 2px 8px rgba(0,0,0,.10);
+  --kp-shadow-lg: 0 4px 20px rgba(0,0,0,.14);
+
+  --kp-transition: 0.14s ease;
+}
+
+/* ─── DARK THEME ─────────────────────────────────────────── */
+[data-theme="dark"] {
+  --kp-bg:             #0d1117;
+  --kp-surface:        #161b22;
+  --kp-surface-hover:  #1c2128;
+  --kp-border:         #30363d;
+  --kp-focus:          #58a6ff;
+
+  --kp-primary:        #58a6ff;
+  --kp-primary-dark:   #79b8ff;
+  --kp-primary-bg:     #1a2942;
+
+  --kp-danger:         #f85149;
+  --kp-danger-dark:    #ff7b72;
+  --kp-danger-bg:      #2d1117;
+
+  --kp-success:        #3fb950;
+  --kp-success-bg:     #0f2c17;
+
+  --kp-warn-bg:        #272115;
+  --kp-warn-border:    #9e7a0e;
+  --kp-warn-text:      #e3b341;
+
+  --kp-text:           #e6edf3;
+  --kp-text-secondary: #8b949e;
+  --kp-text-muted:     #484f58;
+
+  --kp-sidebar-bg:     #0d1117;
+  --kp-sidebar-hover:  #1c2128;
+  --kp-sidebar-active: #1a2942;
+  --kp-sidebar-active-text: #58a6ff;
+
+  --kp-shadow-sm: 0 1px 3px rgba(0,0,0,.3);
+  --kp-shadow:    0 2px 8px rgba(0,0,0,.4);
+  --kp-shadow-lg: 0 4px 20px rgba(0,0,0,.5);
+}
+
+/* ─── RESET (vault scope only) ───────────────────────────── */
+.kp-app, .kp-app * {
+  box-sizing: border-box;
+}
+
+.kp-app {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--kp-text);
+  background: var(--kp-bg);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* override the Bootstrap body padding when inside the vault */
+body:has(.kp-app) {
+  padding-top: 0 !important;
+  overflow: hidden;
+}
+
+/* ─── NAVBAR ─────────────────────────────────────────────── */
+.kp-nav {
+  height: var(--kp-nav-h);
+  background: var(--kp-surface);
+  border-bottom: 1px solid var(--kp-border);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 10px;
+  flex-shrink: 0;
+  box-shadow: var(--kp-shadow-sm);
+  z-index: 100;
+}
+
+.kp-nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--kp-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.kp-nav-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--kp-success);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.kp-nav-status::before {
+  content: '';
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--kp-success);
+  flex-shrink: 0;
+}
+
+.kp-nav-search {
+  flex: 1;
+  max-width: 380px;
+  position: relative;
+}
+.kp-nav-search svg {
+  position: absolute;
+  left: 10px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--kp-text-muted);
+  pointer-events: none;
+}
+.kp-nav-search input {
+  width: 100%;
+  padding: 7px 12px 7px 34px;
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  font-size: 13px;
+  background: var(--kp-bg);
+  color: var(--kp-text);
+  outline: none;
+  transition: border-color var(--kp-transition), box-shadow var(--kp-transition);
+}
+.kp-nav-search input:focus {
+  border-color: var(--kp-focus);
+  box-shadow: 0 0 0 3px rgba(76,154,255,.18);
+  background: var(--kp-surface);
+}
+.kp-nav-search input::placeholder { color: var(--kp-text-muted); }
+
+.kp-nav-spacer { flex: 1; }
+.kp-nav-actions { display: flex; align-items: center; gap: 6px; }
+
+/* ─── BUTTONS ────────────────────────────────────────────── */
+.kp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border: 1px solid transparent;
+  border-radius: var(--kp-r);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1;
+  font-family: inherit;
+  text-decoration: none;
+  transition: background var(--kp-transition), border-color var(--kp-transition), color var(--kp-transition);
+}
+.kp-btn:focus-visible { outline: 2px solid var(--kp-focus); outline-offset: 2px; }
+
+.kp-btn-primary {
+  background: var(--kp-primary);
+  color: #fff;
+  border-color: var(--kp-primary);
+}
+.kp-btn-primary:hover { background: var(--kp-primary-dark); border-color: var(--kp-primary-dark); }
+
+.kp-btn-ghost {
+  background: transparent;
+  color: var(--kp-text-secondary);
+  border-color: transparent;
+  padding: 7px 10px;
+}
+.kp-btn-ghost:hover { background: var(--kp-sidebar-hover); color: var(--kp-text); }
+
+.kp-btn-outline {
+  background: var(--kp-surface);
+  color: var(--kp-text);
+  border-color: var(--kp-border);
+}
+.kp-btn-outline:hover { background: var(--kp-surface-hover); border-color: #b3b9c4; }
+
+.kp-btn-danger-ghost {
+  background: transparent;
+  color: var(--kp-text-muted);
+  border: none;
+  padding: 5px 7px;
+  border-radius: var(--kp-r-sm);
+}
+.kp-btn-danger-ghost:hover { background: var(--kp-danger-bg); color: var(--kp-danger); }
+
+.kp-btn-icon {
+  background: transparent;
+  color: var(--kp-text-muted);
+  border: none;
+  padding: 5px 7px;
+  border-radius: var(--kp-r-sm);
+  cursor: pointer;
+  font-family: inherit;
+}
+.kp-btn-icon:hover { background: var(--kp-sidebar-hover); color: var(--kp-text); }
+
+.kp-btn-sm { padding: 5px 10px; font-size: 12px; gap: 4px; }
+.kp-btn-link {
+  background: none; border: none; padding: 0 4px;
+  color: var(--kp-text-muted); cursor: pointer; font-family: inherit; font-size: inherit;
+}
+.kp-btn-link:hover { color: var(--kp-primary); }
+
+/* ─── DROPDOWN ───────────────────────────────────────────── */
+.kp-dropdown { position: relative; }
+.kp-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 5px); right: 0;
+  background: var(--kp-surface);
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  box-shadow: var(--kp-shadow);
+  min-width: 152px;
+  z-index: 300;
+  padding: 4px;
+  display: none;
+}
+.kp-dropdown.open .kp-dropdown-menu { display: block; }
+.kp-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  font-size: 13px;
+  color: var(--kp-text);
+  background: none;
+  border: none;
+  text-align: left;
+  border-radius: var(--kp-r-sm);
+  cursor: pointer;
+  font-family: inherit;
+}
+.kp-dropdown-item:hover { background: var(--kp-sidebar-hover); }
+.kp-dropdown-item.danger { color: var(--kp-danger); }
+.kp-dropdown-divider { height: 1px; background: var(--kp-border); margin: 4px 0; }
+
+/* ─── LAYOUT ─────────────────────────────────────────────── */
+.kp-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ─── SIDEBAR ────────────────────────────────────────────── */
+.kp-sidebar {
+  width: var(--kp-sidebar-w);
+  background: var(--kp-sidebar-bg);
+  border-right: 1px solid var(--kp-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+  transition: transform var(--kp-transition);
+}
+
+.kp-sidebar-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 14px 14px 8px;
+  position: sticky; top: 0;
+  background: var(--kp-sidebar-bg);
+  z-index: 1;
+}
+.kp-sidebar-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--kp-text-muted);
+}
+.kp-sidebar-count { font-size: 11px; color: var(--kp-text-muted); margin-top: 1px; }
+
+.kp-sidebar-add {
+  width: 22px; height: 22px;
+  display: flex; align-items: center; justify-content: center;
+  border: none; background: none;
+  border-radius: var(--kp-r-sm);
+  color: var(--kp-text-muted);
+  cursor: pointer; flex-shrink: 0;
+  font-family: inherit;
+}
+.kp-sidebar-add:hover { background: var(--kp-sidebar-hover); color: var(--kp-text); }
+
+.kp-tree { padding: 0 6px 16px; }
+
+.kp-tree-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 8px;
+  border-radius: var(--kp-r-sm);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--kp-text);
+  margin-bottom: 1px;
+  user-select: none;
+}
+.kp-tree-item:hover { background: var(--kp-sidebar-hover); }
+.kp-tree-item.active {
+  background: var(--kp-sidebar-active);
+  color: var(--kp-sidebar-active-text);
+  font-weight: 500;
+}
+.kp-tree-expand { opacity: .4; flex-shrink: 0; }
+.kp-tree-item.active .kp-tree-expand { opacity: .7; }
+.kp-tree-icon { flex-shrink: 0; opacity: .7; }
+.kp-tree-item.active .kp-tree-icon { opacity: 1; }
+
+.kp-tree-children { padding-left: 18px; }
+
+/* inline group rename */
+.kp-tree-rename {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  margin-bottom: 1px;
+}
+.kp-tree-rename input {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--kp-focus);
+  border-radius: var(--kp-r-sm);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(76,154,255,.18);
+}
+
+/* ─── CENTER PANEL ───────────────────────────────────────── */
+.kp-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.kp-center-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 12px;
+  background: var(--kp-surface);
+  border-bottom: 1px solid var(--kp-border);
+  position: sticky; top: 0; z-index: 1;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.kp-center-title h2 { font-size: 16px; font-weight: 600; line-height: 1.2; }
+.kp-center-title small { font-size: 12px; color: var(--kp-text-muted); }
+.kp-center-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+/* inline group rename in header */
+.kp-center-title-form {
+  display: flex; align-items: center; gap: 4px;
+}
+.kp-center-title-form input {
+  padding: 4px 8px;
+  border: 1px solid var(--kp-focus);
+  border-radius: var(--kp-r);
+  font-size: 15px; font-weight: 600;
+  font-family: inherit;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(76,154,255,.18);
+  max-width: 220px;
+}
+
+/* badges */
+.kp-badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  font-size: 11px; font-weight: 500;
+}
+.kp-badge-protected {
+  background: var(--kp-warn-bg);
+  color: var(--kp-warn-text);
+  border: 1px solid var(--kp-warn-border);
+}
+
+/* add group inline form */
+.kp-group-form {
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--kp-border);
+  background: var(--kp-surface);
+}
+.kp-group-form form { display: flex; align-items: center; gap: 6px; }
+.kp-group-form input {
+  flex: 1; max-width: 260px;
+  padding: 6px 10px;
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  font-size: 13px; font-family: inherit;
+  outline: none;
+  transition: border-color var(--kp-transition);
+}
+.kp-group-form input:focus { border-color: var(--kp-focus); box-shadow: 0 0 0 3px rgba(76,154,255,.18); }
+
+/* ─── ENTRY CARDS ────────────────────────────────────────── */
+.kp-entries { padding: 12px 14px; display: flex; flex-direction: column; gap: 6px; }
+
+.kp-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  background: var(--kp-surface);
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  cursor: pointer;
+  transition: border-color var(--kp-transition), box-shadow var(--kp-transition);
+}
+.kp-card:hover { border-color: #b3b9c4; box-shadow: var(--kp-shadow-sm); }
+.kp-card.active { border-color: var(--kp-primary); box-shadow: 0 0 0 1px var(--kp-primary); }
+
+.kp-card-icon {
+  width: 36px; height: 36px;
+  border-radius: var(--kp-r-sm);
+  background: var(--kp-primary-bg);
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  color: var(--kp-primary);
+  transition: background var(--kp-transition), color var(--kp-transition);
+}
+.kp-card.active .kp-card-icon { background: var(--kp-primary); color: #fff; }
+
+.kp-card-body { flex: 1; min-width: 0; }
+.kp-card-title {
+  font-size: 14px; font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.kp-card-meta {
+  font-size: 12px; color: var(--kp-text-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.kp-card-actions {
+  display: flex; gap: 2px; flex-shrink: 0;
+  opacity: 0; transition: opacity var(--kp-transition);
+}
+.kp-card:hover .kp-card-actions,
+.kp-card.active .kp-card-actions { opacity: 1; }
+
+/* ─── DETAIL / EDIT PANEL ────────────────────────────────── */
+.kp-detail {
+  width: var(--kp-detail-w);
+  background: var(--kp-surface);
+  border-left: 1px solid var(--kp-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.kp-detail-empty {
+  flex: 1;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 40px 24px;
+  color: var(--kp-text-muted);
+  text-align: center; gap: 10px;
+}
+.kp-detail-empty svg { opacity: .25; }
+.kp-detail-empty p { font-size: 13px; }
+
+.kp-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--kp-border);
+}
+.kp-detail-header h3 { font-size: 15px; font-weight: 600; }
+.kp-detail-header p { font-size: 12px; color: var(--kp-text-muted); margin-top: 2px; }
+
+.kp-detail-entry-meta {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--kp-border);
+}
+.kp-detail-icon {
+  width: 40px; height: 40px;
+  border-radius: var(--kp-r);
+  background: var(--kp-primary-bg);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--kp-primary); flex-shrink: 0;
+}
+.kp-detail-icon-info h4 { font-size: 14px; font-weight: 600; }
+.kp-detail-icon-info p { font-size: 12px; color: var(--kp-text-muted); margin-top: 1px; }
+.kp-detail-modified {
+  margin-left: auto;
+  font-size: 11px; color: var(--kp-text-muted);
+  background: var(--kp-bg); padding: 3px 8px;
+  border-radius: var(--kp-r-sm); border: 1px solid var(--kp-border);
+  white-space: nowrap; flex-shrink: 0;
+}
+
+/* ─── FORM ───────────────────────────────────────────────── */
+.kp-form { padding: 20px; display: flex; flex-direction: column; gap: 16px; }
+
+.kp-form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+.kp-field { display: flex; flex-direction: column; gap: 5px; }
+.kp-field label {
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .05em;
+  color: var(--kp-text-secondary);
+}
+
+.kp-input {
+  padding: 8px 12px;
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  font-size: 14px;
+  color: var(--kp-text);
+  background: var(--kp-surface);
+  outline: none;
+  width: 100%;
+  font-family: inherit;
+  transition: border-color var(--kp-transition), box-shadow var(--kp-transition);
+}
+.kp-input:focus {
+  border-color: var(--kp-focus);
+  box-shadow: 0 0 0 3px rgba(76,154,255,.18);
+}
+.kp-input::placeholder { color: var(--kp-text-muted); }
+
+textarea.kp-input {
+  resize: vertical; min-height: 80px;
+  line-height: 1.5;
+}
+
+.kp-input-group { display: flex; }
+.kp-input-group .kp-input {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  flex: 1;
+}
+.kp-input-group-btns { display: flex; }
+.kp-input-group-btns .kp-btn-outline {
+  border-left: none;
+  border-radius: 0;
+  padding: 7px 10px;
+}
+.kp-input-group-btns .kp-btn-outline:last-child {
+  border-top-right-radius: var(--kp-r);
+  border-bottom-right-radius: var(--kp-r);
+}
+
+.kp-form-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding-top: 8px; border-top: 1px solid var(--kp-border);
+}
+
+/* ─── NODE VIEWER (entry detail read-only) ───────────────── */
+.kp-detail-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.kp-node { padding: 0; display: flex; flex-direction: column; }
+.kp-node-fields { display: flex; flex-direction: column; }
+
+.kp-node-section-label,
+.kp-node-section-header {
+  padding: 10px 20px 6px;
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .06em;
+  color: var(--kp-text-muted);
+  background: var(--kp-bg);
+  border-bottom: 1px solid var(--kp-border);
+  border-top: 1px solid var(--kp-border);
+}
+
+.kp-node-field-value.protected {
+  font-family: 'Courier New', Courier, monospace;
+  letter-spacing: .05em;
+  color: var(--kp-text-muted);
+}
+
+.kp-node-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--kp-border);
+}
+.kp-node-field-label {
+  width: 90px; flex-shrink: 0;
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .05em;
+  color: var(--kp-text-secondary);
+  padding-top: 2px;
+}
+.kp-node-field-value {
+  flex: 1; min-width: 0;
+  font-size: 14px; color: var(--kp-text);
+  word-break: break-all;
+}
+.kp-node-field-value a { color: var(--kp-primary); text-decoration: none; }
+.kp-node-field-value a:hover { text-decoration: underline; }
+.kp-node-field-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.kp-node-section-header {
+  padding: 10px 20px 6px;
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .06em;
+  color: var(--kp-text-muted);
+  background: var(--kp-bg);
+  border-bottom: 1px solid var(--kp-border);
+}
+
+/* ─── LOADING MASK ───────────────────────────────────────── */
+.kp-loading { position: relative; }
+.kp-loading::before {
+  content: '';
+  position: absolute; inset: 0;
+  background: rgba(255,255,255,.55);
+  z-index: 10;
+  border-radius: inherit;
+}
+.kp-loading::after {
+  content: '';
+  position: absolute;
+  width: 24px; height: 24px;
+  top: calc(50% - 12px); left: calc(50% - 12px);
+  border: 2px solid var(--kp-border);
+  border-top-color: var(--kp-primary);
+  border-radius: 50%;
+  animation: kp-spin .7s linear infinite;
+  z-index: 11;
+}
+@keyframes kp-spin { to { transform: rotate(360deg); } }
+
+/* ─── DETAIL NOTE ────────────────────────────────────────── */
+.kp-detail-note {
+  margin: 0 20px 20px;
+  padding: 10px 14px;
+  background: var(--kp-bg); border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r); font-size: 12px; color: var(--kp-text-muted);
+  line-height: 1.6;
+}
+
+/* ─── OVERLAY (mobile) ───────────────────────────────────── */
+.kp-overlay {
+  display: none;
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.35);
+  z-index: 49;
+}
+.kp-overlay.show { display: block; }
+
+.kp-sidebar-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.35);
+  z-index: 50;
+}
+
+/* ─── SAVE MODAL ─────────────────────────────────────────── */
+.kp-modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.4);
+  z-index: 200;
+  display: flex; align-items: center; justify-content: center;
+}
+.kp-modal {
+  background: var(--kp-surface);
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r-lg);
+  padding: 24px;
+  width: 340px;
+  box-shadow: var(--kp-shadow-lg);
+}
+.kp-modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.kp-modal-header h3 { font-size: 16px; font-weight: 600; }
+.kp-modal h4 { font-size: 15px; font-weight: 600; margin-bottom: 6px; }
+.kp-modal p { font-size: 13px; color: var(--kp-text-secondary); margin-bottom: 16px; }
+.kp-modal .kp-form-actions { border-top: none; padding-top: 0; }
+
+/* ─── RESPONSIVE ─────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  :root { --kp-detail-w: 360px; }
+}
+
+@media (max-width: 900px) {
+  :root { --kp-detail-w: 100%; }
+  .kp-detail {
+    position: fixed;
+    inset: var(--kp-nav-h) 0 0 0;
+    z-index: 50;
+    transform: translateY(100%);
+    transition: transform .22s cubic-bezier(.4,0,.2,1);
+    border-left: none;
+    border-top: 1px solid var(--kp-border);
+    box-shadow: var(--kp-shadow-lg);
+  }
+  .kp-detail.open { transform: translateY(0); }
+}
+
+@media (max-width: 700px) {
+  .kp-sidebar {
+    position: fixed;
+    inset: var(--kp-nav-h) auto 0 0;
+    z-index: 51;
+    transform: translateX(-110%);
+    transition: transform .22s cubic-bezier(.4,0,.2,1);
+    box-shadow: var(--kp-shadow-lg);
+  }
+  .kp-sidebar.open { transform: translateX(0); }
+  .kp-nav-status { display: none; }
+  .kp-sidebar-toggle { display: flex !important; }
+}
+
+@media (max-width: 480px) {
+  .kp-nav-search { display: none; }
+  .kp-form-row { grid-template-columns: 1fr; }
+}
+
+/* ─── LOGIN PAGE ─────────────────────────────────────────── */
+.kp-login {
+  margin-top: 72px;
+  padding: 32px 28px;
+  width: auto; height: auto;
+  min-width: 340px; max-width: 420px;
+  background: #ffffff;
+  margin-left: auto; margin-right: auto;
+  border-radius: var(--kp-r-lg);
+  border: 1px solid var(--kp-border);
+  box-shadow: var(--kp-shadow);
+}
+.kp-login-inner {
+  max-width: 360px; margin: 0 auto;
+  display: flex; flex-direction: column; gap: 18px;
+}
+
+.kp-login-icon {
+  width: 52px; height: 52px;
+  border-radius: 14px;
+  background: var(--kp-primary-bg);
+  color: var(--kp-primary);
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto 2px;
+}
+
+.kp-login-inner h4 {
+  font-size: 20px; font-weight: 700;
+  text-align: center; margin: 0;
+  color: var(--kp-text);
+}
+.kp-login-sub {
+  font-size: 13px; color: var(--kp-text-muted);
+  text-align: center; margin: -10px 0 0;
+}
+
+.kp-login-field {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.kp-login-field label {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 12px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .05em;
+  color: var(--kp-text-secondary);
+}
+.kp-login-optional {
+  margin-left: auto;
+  font-size: 10px; font-weight: 500;
+  text-transform: none; letter-spacing: 0;
+  color: var(--kp-text-muted);
+  background: var(--kp-bg);
+  padding: 1px 7px; border-radius: 10px;
+  border: 1px solid var(--kp-border);
+}
+
+/* custom file picker */
+.kp-file-label {
+  display: flex; align-items: center; gap: 8px;
+  padding: 9px 14px;
+  border: 1.5px dashed var(--kp-border);
+  border-radius: var(--kp-r);
+  font-size: 13px; color: var(--kp-text-muted);
+  cursor: pointer;
+  transition: border-color var(--kp-transition), background var(--kp-transition);
+  background: var(--kp-bg);
+  user-select: none;
+}
+.kp-file-label:hover { border-color: var(--kp-primary); color: var(--kp-primary); background: var(--kp-primary-bg); }
+.kp-file-label.has-file {
+  border-style: solid; border-color: var(--kp-success);
+  color: var(--kp-success); background: var(--kp-success-bg);
+}
+.kp-file-label svg { flex-shrink: 0; }
+
+.kp-btn-open {
+  width: 100%; justify-content: center;
+  padding: 11px 0; font-size: 15px; font-weight: 600;
+  border-radius: var(--kp-r);
+}
+
+/* dark login card */
+[data-theme="dark"] .kp-login { background: var(--kp-surface); }
+
+/* ─── THEME TOGGLE BUTTON ────────────────────────────────── */
+.kp-theme-toggle {
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r);
+  background: transparent;
+  color: var(--kp-text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--kp-transition), color var(--kp-transition);
+  font-family: inherit;
+}
+.kp-theme-toggle:hover { background: var(--kp-sidebar-hover); color: var(--kp-text); }
+
+/* ─── ICON PICKER ────────────────────────────────────────── */
+.kp-icon-trigger {
+  width: 44px; height: 44px;
+  border-radius: var(--kp-r);
+  border: 2px solid var(--kp-border);
+  background: var(--kp-bg);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: border-color var(--kp-transition);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.kp-icon-trigger:hover { border-color: var(--kp-primary); }
+.kp-icon-trigger img { width: 28px; height: 28px; object-fit: contain; }
+
+.kp-icon-picker-wrap {
+  position: relative;
+}
+
+.kp-icon-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 400;
+  background: var(--kp-surface);
+  border: 1px solid var(--kp-border);
+  border-radius: var(--kp-r-lg);
+  box-shadow: var(--kp-shadow-lg);
+  padding: 12px;
+  width: 320px;
+}
+.kp-icon-picker-label {
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .06em;
+  color: var(--kp-text-muted);
+  margin-bottom: 8px;
+}
+.kp-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.kp-icon-grid-item {
+  width: 28px; height: 28px;
+  border-radius: var(--kp-r-sm);
+  border: 1.5px solid transparent;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  transition: border-color var(--kp-transition), background var(--kp-transition);
+  padding: 2px;
+}
+.kp-icon-grid-item:hover { background: var(--kp-sidebar-hover); border-color: var(--kp-border); }
+.kp-icon-grid-item.selected { border-color: var(--kp-primary); background: var(--kp-primary-bg); }
+.kp-icon-grid-item img { width: 18px; height: 18px; object-fit: contain; }
+
+.kp-form-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+.kp-form-icon-row .kp-field { flex: 1; }

--- a/public/preview.html
+++ b/public/preview.html
@@ -1,0 +1,936 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KeePass 4 Web — UI Preview</title>
+  <style>
+    /* ─── RESET ─────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    button { font-family: inherit; cursor: pointer; }
+    input, textarea { font-family: inherit; }
+    a { text-decoration: none; }
+
+    /* ─── DESIGN TOKENS ──────────────────────────────────── */
+    :root {
+      --bg:               #f4f5f7;
+      --surface:          #ffffff;
+      --surface-hover:    #f8f9fb;
+      --border:           #dfe1e6;
+      --border-focus:     #4c9aff;
+
+      --primary:          #1b6bde;
+      --primary-dark:     #1558b5;
+      --primary-bg:       #e8f0fd;
+      --primary-text:     #ffffff;
+
+      --danger:           #d63638;
+      --danger-dark:      #b32d2f;
+      --danger-bg:        #fff0f0;
+
+      --success:          #0a7c4c;
+      --success-bg:       #e3fcef;
+
+      --warn-bg:          #fffae6;
+      --warn-border:      #f6c000;
+      --warn-text:        #6e4e00;
+
+      --text-primary:     #1a2332;
+      --text-secondary:   #5e6c84;
+      --text-muted:       #97a0af;
+
+      --sidebar-bg:       #fafbfc;
+      --sidebar-hover:    #eaecf0;
+      --sidebar-active:   #dce8ff;
+      --sidebar-active-t: #1b6bde;
+
+      --nav-h:            52px;
+      --sidebar-w:        224px;
+      --detail-w:         440px;
+
+      --r-sm:  4px;
+      --r:     6px;
+      --r-lg:  10px;
+
+      --shadow-sm: 0 1px 3px rgba(0,0,0,.07);
+      --shadow:    0 2px 8px rgba(0,0,0,.10);
+      --shadow-lg: 0 4px 20px rgba(0,0,0,.14);
+
+      --transition: 0.14s ease;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--text-primary);
+      background: var(--bg);
+    }
+
+    /* ─── NAVBAR ─────────────────────────────────────────── */
+    .nav {
+      position: fixed;
+      inset: 0 0 auto 0;
+      height: var(--nav-h);
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      padding: 0 16px;
+      gap: 10px;
+      z-index: 100;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--primary);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .nav-status {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 12px;
+      color: var(--success);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .nav-status::before {
+      content: '';
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--success);
+      flex-shrink: 0;
+    }
+
+    .nav-search {
+      flex: 1;
+      max-width: 380px;
+      position: relative;
+    }
+    .nav-search svg {
+      position: absolute;
+      left: 10px; top: 50%;
+      transform: translateY(-50%);
+      color: var(--text-muted);
+      pointer-events: none;
+    }
+    .nav-search input {
+      width: 100%;
+      padding: 7px 12px 7px 34px;
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      font-size: 13px;
+      background: var(--bg);
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color var(--transition), box-shadow var(--transition);
+    }
+    .nav-search input:focus {
+      border-color: var(--border-focus);
+      box-shadow: 0 0 0 3px rgba(76,154,255,.18);
+      background: var(--surface);
+    }
+    .nav-search input::placeholder { color: var(--text-muted); }
+
+    .nav-spacer { flex: 1; }
+
+    .nav-actions { display: flex; align-items: center; gap: 6px; }
+
+    /* ─── BUTTONS ────────────────────────────────────────── */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 14px;
+      border: 1px solid transparent;
+      border-radius: var(--r);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      white-space: nowrap;
+      line-height: 1;
+      transition: background var(--transition), border-color var(--transition), color var(--transition);
+    }
+    .btn:focus-visible { outline: 2px solid var(--border-focus); outline-offset: 2px; }
+
+    .btn-primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+    .btn-primary:hover { background: var(--primary-dark); border-color: var(--primary-dark); }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-secondary);
+      border-color: transparent;
+      padding: 7px 10px;
+    }
+    .btn-ghost:hover { background: var(--sidebar-hover); color: var(--text-primary); }
+
+    .btn-outline {
+      background: var(--surface);
+      color: var(--text-primary);
+      border-color: var(--border);
+    }
+    .btn-outline:hover { background: var(--surface-hover); border-color: #b3b9c4; }
+
+    .btn-danger-ghost {
+      background: transparent;
+      color: var(--text-muted);
+      border-color: transparent;
+      padding: 5px 7px;
+    }
+    .btn-danger-ghost:hover { background: var(--danger-bg); color: var(--danger); }
+
+    .btn-icon-sm {
+      background: transparent;
+      color: var(--text-muted);
+      border: none;
+      padding: 5px 7px;
+      border-radius: var(--r-sm);
+    }
+    .btn-icon-sm:hover { background: var(--sidebar-hover); color: var(--text-primary); }
+
+    .btn-sm { padding: 5px 10px; font-size: 12px; gap: 4px; }
+
+    /* ─── DROPDOWN ───────────────────────────────────────── */
+    .dropdown { position: relative; }
+    .dropdown-menu {
+      position: absolute;
+      top: calc(100% + 5px); right: 0;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      box-shadow: var(--shadow);
+      min-width: 150px;
+      z-index: 300;
+      padding: 4px;
+      display: none;
+    }
+    .dropdown.open .dropdown-menu { display: block; }
+    .dropdown-item {
+      display: block;
+      width: 100%;
+      padding: 7px 12px;
+      font-size: 13px;
+      color: var(--text-primary);
+      background: none;
+      border: none;
+      text-align: left;
+      border-radius: var(--r-sm);
+      cursor: pointer;
+    }
+    .dropdown-item:hover { background: var(--sidebar-hover); }
+    .dropdown-item.danger { color: var(--danger); }
+    .dropdown-divider { height: 1px; background: var(--border); margin: 4px 0; }
+
+    /* ─── MAIN LAYOUT ────────────────────────────────────── */
+    .layout {
+      display: flex;
+      height: 100vh;
+      padding-top: var(--nav-h);
+      overflow: hidden;
+    }
+
+    /* ─── SIDEBAR ────────────────────────────────────────── */
+    .sidebar {
+      width: var(--sidebar-w);
+      background: var(--sidebar-bg);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+      flex-shrink: 0;
+      transition: transform var(--transition);
+    }
+
+    .sidebar-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding: 14px 14px 8px;
+      position: sticky; top: 0;
+      background: var(--sidebar-bg);
+      z-index: 1;
+    }
+    .sidebar-label {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+    .sidebar-count { font-size: 11px; color: var(--text-muted); margin-top: 1px; }
+
+    .sidebar-add {
+      width: 22px; height: 22px;
+      display: flex; align-items: center; justify-content: center;
+      border: none; background: none;
+      border-radius: var(--r-sm);
+      color: var(--text-muted);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .sidebar-add:hover { background: var(--sidebar-hover); color: var(--text-primary); }
+
+    .tree { padding: 0 6px 16px; }
+
+    .tree-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 8px;
+      border-radius: var(--r-sm);
+      cursor: pointer;
+      font-size: 13px;
+      color: var(--text-primary);
+      margin-bottom: 1px;
+      user-select: none;
+    }
+    .tree-item:hover { background: var(--sidebar-hover); }
+    .tree-item.active {
+      background: var(--sidebar-active);
+      color: var(--sidebar-active-t);
+      font-weight: 500;
+    }
+    .tree-item svg { flex-shrink: 0; }
+    .tree-expand { opacity: .4; }
+    .tree-item.active .tree-expand { opacity: .7; }
+
+    .tree-children { padding-left: 18px; }
+
+    /* ─── CENTER PANEL ───────────────────────────────────── */
+    .center {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+      min-width: 0;
+    }
+
+    .center-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 18px 12px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      position: sticky; top: 0; z-index: 1;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .center-title h2 { font-size: 16px; font-weight: 600; }
+    .center-title small { font-size: 12px; color: var(--text-muted); }
+
+    .center-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+    .badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 3px 9px;
+      border-radius: 20px;
+      font-size: 11px; font-weight: 500;
+    }
+    .badge-protected {
+      background: var(--warn-bg);
+      color: var(--warn-text);
+      border: 1px solid var(--warn-border);
+    }
+
+    .entries { padding: 12px 14px; display: flex; flex-direction: column; gap: 6px; }
+
+    /* ─── ENTRY CARDS ────────────────────────────────────── */
+    .card {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 11px 14px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      cursor: pointer;
+      transition: border-color var(--transition), box-shadow var(--transition);
+    }
+    .card:hover { border-color: #b3b9c4; box-shadow: var(--shadow-sm); }
+    .card.active { border-color: var(--primary); box-shadow: 0 0 0 1px var(--primary); }
+
+    .card-icon {
+      width: 36px; height: 36px;
+      border-radius: var(--r-sm);
+      background: var(--primary-bg);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+      color: var(--primary);
+    }
+    .card.active .card-icon { background: var(--primary); color: #fff; }
+
+    .card-body { flex: 1; min-width: 0; }
+    .card-title {
+      font-size: 14px; font-weight: 500;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .card-meta {
+      font-size: 12px; color: var(--text-muted);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      margin-top: 2px;
+    }
+
+    .card-actions {
+      display: flex; gap: 2px; flex-shrink: 0;
+      opacity: 0; transition: opacity var(--transition);
+    }
+    .card:hover .card-actions,
+    .card.active .card-actions { opacity: 1; }
+
+    /* ─── DETAIL / EDIT PANEL ────────────────────────────── */
+    .detail {
+      width: var(--detail-w);
+      background: var(--surface);
+      border-left: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+      flex-shrink: 0;
+      transition: transform var(--transition);
+    }
+
+    .detail-header {
+      padding: 16px 20px 12px;
+      border-bottom: 1px solid var(--border);
+    }
+    .detail-header h3 { font-size: 15px; font-weight: 600; }
+    .detail-header p { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+
+    .detail-entry-meta {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .detail-icon {
+      width: 40px; height: 40px;
+      border-radius: var(--r);
+      background: var(--primary-bg);
+      display: flex; align-items: center; justify-content: center;
+      color: var(--primary); flex-shrink: 0;
+    }
+    .detail-icon-info h4 { font-size: 14px; font-weight: 600; }
+    .detail-icon-info p { font-size: 12px; color: var(--text-muted); margin-top: 1px; }
+
+    .detail-modified {
+      margin-left: auto;
+      font-size: 11px; color: var(--text-muted);
+      background: var(--bg);
+      padding: 3px 8px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border);
+      white-space: nowrap;
+    }
+
+    /* ─── FORM ───────────────────────────────────────────── */
+    .form { padding: 20px; display: flex; flex-direction: column; gap: 16px; }
+
+    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+
+    .field { display: flex; flex-direction: column; gap: 5px; }
+
+    .field label {
+      font-size: 11px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: .05em;
+      color: var(--text-secondary);
+    }
+
+    .input {
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      font-size: 14px;
+      color: var(--text-primary);
+      background: var(--surface);
+      outline: none;
+      width: 100%;
+      transition: border-color var(--transition), box-shadow var(--transition);
+    }
+    .input:focus {
+      border-color: var(--border-focus);
+      box-shadow: 0 0 0 3px rgba(76,154,255,.18);
+    }
+    .input::placeholder { color: var(--text-muted); }
+
+    textarea.input { resize: vertical; min-height: 80px; font-family: inherit; line-height: 1.5; }
+
+    .input-group { display: flex; }
+    .input-group .input { border-radius: var(--r) 0 0 var(--r); flex: 1; }
+    .input-group-btns { display: flex; }
+    .input-group-btns .btn-outline {
+      border-left: none; border-radius: 0;
+    }
+    .input-group-btns .btn-outline:last-child { border-radius: 0 var(--r) var(--r) 0; }
+
+    .form-actions {
+      display: flex; gap: 8px; justify-content: flex-end;
+      padding-top: 8px; border-top: 1px solid var(--border);
+    }
+
+    .detail-note {
+      margin: 0 20px 20px;
+      padding: 10px 14px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      font-size: 12px; color: var(--text-muted);
+      line-height: 1.6;
+    }
+
+    /* ─── SIDEBAR TOGGLE (mobile) ────────────────────────── */
+    .sidebar-toggle {
+      display: none;
+      background: none;
+      border: none;
+      padding: 7px;
+      border-radius: var(--r-sm);
+      cursor: pointer;
+      color: var(--text-secondary);
+    }
+    .sidebar-toggle:hover { background: var(--sidebar-hover); }
+
+    /* ─── RESPONSIVE ─────────────────────────────────────── */
+    @media (max-width: 1100px) {
+      :root { --detail-w: 360px; }
+    }
+
+    @media (max-width: 900px) {
+      :root { --detail-w: 100%; }
+      .detail {
+        position: fixed;
+        inset: var(--nav-h) 0 0 0;
+        z-index: 50;
+        transform: translateY(100%);
+        transition: transform .22s cubic-bezier(.4,0,.2,1);
+        border-left: none;
+        border-top: 1px solid var(--border);
+        box-shadow: var(--shadow-lg);
+      }
+      .detail.open { transform: translateY(0); }
+    }
+
+    @media (max-width: 700px) {
+      .sidebar {
+        position: fixed;
+        inset: var(--nav-h) auto 0 0;
+        z-index: 51;
+        transform: translateX(-110%);
+        transition: transform .22s cubic-bezier(.4,0,.2,1);
+        box-shadow: var(--shadow-lg);
+      }
+      .sidebar.open { transform: translateX(0); }
+      .sidebar-toggle { display: flex; align-items: center; }
+      .nav-status { display: none; }
+    }
+
+    @media (max-width: 480px) {
+      .nav-search { display: none; }
+      .form-row { grid-template-columns: 1fr; }
+    }
+
+    /* ─── OVERLAY ────────────────────────────────────────── */
+    .overlay {
+      display: none;
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,.35);
+      z-index: 49;
+    }
+    .overlay.show { display: block; }
+  </style>
+</head>
+<body>
+
+<!-- ═══ NAVBAR ═══════════════════════════════════════════ -->
+<nav class="nav">
+  <button class="sidebar-toggle" id="js-sidebar-toggle" aria-label="Toggle sidebar" onclick="toggleSidebar()">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+    </svg>
+  </button>
+
+  <a href="#" class="nav-brand">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 2 3 7v6c0 5.25 3.75 10.15 9 11.25C17.25 23.15 21 18.25 21 13V7z"/>
+    </svg>
+    KeePass 4 Web
+  </a>
+
+  <span class="nav-status">Vault unlocked · autosaved 4 min ago</span>
+
+  <div class="nav-search">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+    </svg>
+    <input type="search" placeholder="Search entries, usernames, URLs…">
+  </div>
+
+  <div class="nav-spacer"></div>
+
+  <div class="nav-actions">
+    <button class="btn btn-ghost">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/>
+      </svg>
+      Sync
+    </button>
+
+    <div class="dropdown" id="user-menu">
+      <button class="btn btn-ghost" onclick="toggleDropdown('user-menu')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+          <circle cx="12" cy="7" r="4"/>
+        </svg>
+        testuser
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+      </button>
+      <div class="dropdown-menu">
+        <button class="dropdown-item">Logout</button>
+        <div class="dropdown-divider"></div>
+        <button class="dropdown-item danger">Close Vault</button>
+      </div>
+    </div>
+
+    <button class="btn btn-primary" onclick="openSaveModal()">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+        <polyline points="17 21 17 13 7 13 7 21"/>
+        <polyline points="7 3 7 8 15 8"/>
+      </svg>
+      Save
+    </button>
+  </div>
+</nav>
+
+<!-- ═══ OVERLAY (mobile) ═════════════════════════════════ -->
+<div class="overlay" id="overlay" onclick="closeSidebar()"></div>
+
+<!-- ═══ LAYOUT ═══════════════════════════════════════════ -->
+<div class="layout">
+
+  <!-- ── SIDEBAR ──────────────────────────────────────── -->
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+      <div>
+        <div class="sidebar-label">Groups</div>
+        <div class="sidebar-count">2 folders</div>
+      </div>
+      <button class="sidebar-add" title="Add group" onclick="alert('Add group')">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+          <path d="M12 5v14M5 12h14"/>
+        </svg>
+      </button>
+    </div>
+
+    <div class="tree">
+      <!-- Root -->
+      <div class="tree-item" onclick="selectGroup(this)">
+        <svg class="tree-expand" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+          <path d="m6 9 6 6 6-6"/>
+        </svg>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+        </svg>
+        Root
+      </div>
+      <div class="tree-children">
+        <div class="tree-item active" onclick="selectGroup(this)">
+          <svg class="tree-expand" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="opacity:0">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+          servers
+        </div>
+        <div class="tree-item" onclick="selectGroup(this)">
+          <svg class="tree-expand" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="opacity:0">
+            <path d="m6 9 6 6 6-6"/>
+          </svg>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+          group2
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ── CENTER PANEL ──────────────────────────────────── -->
+  <main class="center">
+    <div class="center-header">
+      <div class="center-title">
+        <h2>servers</h2>
+        <small>2 saved entries</small>
+      </div>
+      <div class="center-actions">
+        <span class="badge badge-protected">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <rect x="3" y="11" width="18" height="11" rx="2"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+          protected
+        </span>
+        <button class="btn btn-primary btn-sm" onclick="openPanel('new', null)">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <path d="M12 5v14M5 12h14"/>
+          </svg>
+          New Entry
+        </button>
+      </div>
+    </div>
+
+    <div class="entries">
+      <!-- Card 1 (active) -->
+      <div class="card active" id="card-1" onclick="openPanel('edit', 1)">
+        <div class="card-icon">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8M12 17v4"/>
+          </svg>
+        </div>
+        <div class="card-body">
+          <div class="card-title">entry1</div>
+          <div class="card-meta">someusr · https://server1.local</div>
+        </div>
+        <div class="card-actions">
+          <button class="btn-icon-sm" title="Edit" onclick="event.stopPropagation(); openPanel('edit',1)">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+              <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"/>
+            </svg>
+          </button>
+          <button class="btn-danger-ghost" title="Delete" onclick="event.stopPropagation()">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Card 2 -->
+      <div class="card" id="card-2" onclick="openPanel('edit', 2)">
+        <div class="card-icon">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <ellipse cx="12" cy="5" rx="9" ry="3"/>
+            <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/>
+            <path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/>
+          </svg>
+        </div>
+        <div class="card-body">
+          <div class="card-title">entry1 - database admin</div>
+          <div class="card-meta">someusr · https://db.local</div>
+        </div>
+        <div class="card-actions">
+          <button class="btn-icon-sm" title="Edit" onclick="event.stopPropagation(); openPanel('edit',2)">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+              <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"/>
+            </svg>
+          </button>
+          <button class="btn-danger-ghost" title="Delete" onclick="event.stopPropagation()">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- ── DETAIL / EDIT PANEL ───────────────────────────── -->
+  <aside class="detail open" id="detail">
+    <div class="detail-header">
+      <h3 id="panel-title">Edit Entry</h3>
+      <p id="panel-subtitle">Credentials stay local to the vault</p>
+    </div>
+
+    <div class="detail-entry-meta" id="panel-meta">
+      <div class="detail-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="2" y="3" width="20" height="14" rx="2"/>
+          <path d="M8 21h8M12 17v4"/>
+        </svg>
+      </div>
+      <div class="detail-icon-info">
+        <h4 id="panel-entry-name">entry1</h4>
+        <p id="panel-entry-path">servers / entry1</p>
+      </div>
+      <span class="detail-modified" id="panel-modified">Last modified today</span>
+    </div>
+
+    <div class="form">
+      <div class="form-row">
+        <div class="field">
+          <label for="f-title">Title</label>
+          <input class="input" id="f-title" type="text" value="entry1" placeholder="Entry title">
+        </div>
+        <div class="field">
+          <label for="f-username">Username</label>
+          <input class="input" id="f-username" type="text" value="someusr" placeholder="Username">
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="f-password">Password</label>
+        <div class="input-group">
+          <input class="input" id="f-password" type="password" value="supersecretpassword" placeholder="Password">
+          <div class="input-group-btns">
+            <button class="btn btn-outline" type="button" onclick="togglePw()" title="Show / hide password">
+              <svg id="eye-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                <circle cx="12" cy="12" r="3"/>
+              </svg>
+            </button>
+            <button class="btn btn-outline" type="button" onclick="genPw()" title="Generate password">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="f-url">URL</label>
+        <input class="input" id="f-url" type="url" value="https://server1.local" placeholder="https://…">
+      </div>
+
+      <div class="field">
+        <label for="f-notes">Notes</label>
+        <textarea class="input" id="f-notes">Linux server credential used for maintenance tasks.</textarea>
+      </div>
+
+      <div class="form-actions">
+        <button class="btn btn-outline" onclick="closePanel()">Cancel</button>
+        <button class="btn btn-primary">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+            <polyline points="17 21 17 13 7 13 7 21"/>
+            <polyline points="7 3 7 8 15 8"/>
+          </svg>
+          Save Entry
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-note">
+      On desktop the form lives in a dedicated details panel; on mobile it slides up from the bottom instead of breaking the card layout.
+    </div>
+  </aside>
+
+</div><!-- /.layout -->
+
+<script>
+  /* ── Dropdown ───────────────────────────────────── */
+  function toggleDropdown(id) {
+    const el = document.getElementById(id);
+    el.classList.toggle('open');
+  }
+  document.addEventListener('click', e => {
+    if (!e.target.closest('.dropdown')) {
+      document.querySelectorAll('.dropdown.open').forEach(d => d.classList.remove('open'));
+    }
+  });
+
+  /* ── Sidebar (mobile) ───────────────────────────── */
+  function toggleSidebar() {
+    document.getElementById('sidebar').classList.toggle('open');
+    document.getElementById('overlay').classList.toggle('show');
+  }
+  function closeSidebar() {
+    document.getElementById('sidebar').classList.remove('open');
+    document.getElementById('overlay').classList.remove('show');
+  }
+
+  /* ── Group selection ────────────────────────────── */
+  function selectGroup(el) {
+    document.querySelectorAll('.tree-item').forEach(i => i.classList.remove('active'));
+    el.classList.add('active');
+    closeSidebar();
+  }
+
+  /* ── Detail panel ───────────────────────────────── */
+  const entries = {
+    1: { title: 'entry1', path: 'servers / entry1', username: 'someusr', url: 'https://server1.local', notes: 'Linux server credential used for maintenance tasks.' },
+    2: { title: 'entry1 - database admin', path: 'servers / entry1 - database admin', username: 'someusr', url: 'https://db.local', notes: '' },
+  };
+
+  function openPanel(mode, id) {
+    const panel = document.getElementById('detail');
+    panel.classList.add('open');
+
+    document.querySelectorAll('.card').forEach(c => c.classList.remove('active'));
+
+    if (mode === 'new') {
+      document.getElementById('panel-title').textContent = 'New Entry';
+      document.getElementById('panel-entry-name').textContent = 'New Entry';
+      document.getElementById('panel-entry-path').textContent = 'servers / new';
+      document.getElementById('panel-modified').style.display = 'none';
+      document.getElementById('f-title').value = '';
+      document.getElementById('f-username').value = '';
+      document.getElementById('f-password').value = '';
+      document.getElementById('f-url').value = '';
+      document.getElementById('f-notes').value = '';
+    } else {
+      const d = entries[id];
+      document.getElementById('panel-title').textContent = 'Edit Entry';
+      document.getElementById('panel-entry-name').textContent = d.title;
+      document.getElementById('panel-entry-path').textContent = d.path;
+      document.getElementById('panel-modified').style.display = '';
+      document.getElementById('f-title').value = d.title;
+      document.getElementById('f-username').value = d.username;
+      document.getElementById('f-password').value = '';
+      document.getElementById('f-url').value = d.url;
+      document.getElementById('f-notes').value = d.notes;
+      document.getElementById('card-' + id).classList.add('active');
+    }
+  }
+
+  function closePanel() {
+    document.getElementById('detail').classList.remove('open');
+    document.querySelectorAll('.card').forEach(c => c.classList.remove('active'));
+  }
+
+  /* ── Password toggle ────────────────────────────── */
+  function togglePw() {
+    const inp = document.getElementById('f-password');
+    const icon = document.getElementById('eye-icon');
+    if (inp.type === 'password') {
+      inp.type = 'text';
+      icon.innerHTML = '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>';
+    } else {
+      inp.type = 'password';
+      icon.innerHTML = '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>';
+    }
+  }
+
+  /* ── Generate password ──────────────────────────── */
+  function genPw() {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}';
+    const arr = new Uint8Array(20);
+    crypto.getRandomValues(arr);
+    const pw = Array.from(arr).map(b => chars[b % chars.length]).join('');
+    const inp = document.getElementById('f-password');
+    inp.type = 'text'; inp.value = pw;
+  }
+
+  /* ── Save modal (placeholder) ───────────────────── */
+  function openSaveModal() {
+    const pw = prompt('Re-enter master password to save to disk:');
+    if (pw) alert('Vault saved ✓');
+  }
+</script>
+</body>
+</html>

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -180,7 +180,7 @@ async fn get_login_type(request: &HttpRequest) -> Result<LoginType> {
     };
     let session = request.get_session();
     let host = format!("{}://{}", request.connection_info().scheme(), request.connection_info().host());
-    let login_type = auth_backend::new(config).get_login_type(&host, cache)?;
+    let login_type = auth_backend::new(config).get_login_type(&host, cache).await?;
 
     match &login_type {
         Redirect { state, .. } => {

--- a/src/auth_backend.rs
+++ b/src/auth_backend.rs
@@ -66,7 +66,9 @@ pub trait AuthBackend: Send + Sync {
 
     fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
 
-    //  TODO: handle case sensitivity
+    // backends returning case-insensitive user names must lowercase
+    // UserInfo.id: it keys the db cache (see ldap/htpasswd). OIDC subjects
+    // are case-sensitive opaque strings and are used as-is.
     async fn login(&self, _username: &str, _password: &str) -> Result<UserInfo> {
         bail!("login method not supported")
     }

--- a/src/auth_backend.rs
+++ b/src/auth_backend.rs
@@ -62,9 +62,9 @@ pub trait AuthBackend: Send + Sync {
 
     async fn init(&self) -> Result<AuthCache> { Ok(Box::new(())) }
 
-    fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType>;
+    async fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType>;
 
-    fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
+    async fn get_logout_type(&self, _user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> { Ok(LogoutType::None) }
 
     // backends returning case-insensitive user names must lowercase
     // UserInfo.id: it keys the db cache (see ldap/htpasswd). OIDC subjects

--- a/src/auth_backend/htpasswd.rs
+++ b/src/auth_backend/htpasswd.rs
@@ -39,7 +39,7 @@ impl AuthBackend for Htpasswd {
         self.config.validate()
     }
 
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/auth_backend/htpasswd.rs
+++ b/src/auth_backend/htpasswd.rs
@@ -48,7 +48,8 @@ impl AuthBackend for Htpasswd {
 
         Ok(
             UserInfo {
-                id: username.to_owned(),
+                // lowercase like the ldap backend, the id keys the db cache
+                id: username.to_lowercase(),
                 name: username.to_owned(),
                 db_location: None,
                 keyfile_location: None,

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -48,7 +48,7 @@ impl AuthBackend for Ldap {
         self.config.validate()
     }
 
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -18,6 +18,20 @@ impl Ldap {
             config: config.ldap.clone()
         }
     }
+
+    // resulting filter: (&(<login_attribute>=<username>)<configured filter>),
+    // or just (<login_attribute>=<username>) if no filter is configured
+    fn search_filter(&self, username: &str) -> String {
+        let user_match = format!(
+            "({}={})",
+            self.config.login_attribute,
+            ldap_escape(username),
+        );
+        match self.config.filter.trim() {
+            "" | "()" => user_match,
+            filter => format!("(&{}{})", user_match, filter),
+        }
+    }
 }
 
 #[async_trait]
@@ -27,13 +41,19 @@ impl AuthBackend for Ldap {
     }
 
     async fn login(&self, username: &str, password: &str) -> Result<UserInfo> {
+        // an empty password would result in an anonymous bind, which most ldap
+        // servers report as success, bypassing the password check entirely
+        if password.is_empty() {
+            bail!("empty password");
+        }
+
         let (conn, mut ldap) = LdapConnAsync::new(self.config.uri.as_str()).await?;
 
         drive!(conn);
         ldap.simple_bind(
             self.config.bind.as_str(),
             self.config.password.as_str(),
-        ).await?;
+        ).await?.success()?;
 
         let mut attrs = vec![CN_ATTR];
         if let Some(k) = &self.config.database_attribute {
@@ -44,25 +64,22 @@ impl AuthBackend for Ldap {
         }
 
         // find user dn
+        let filter = self.search_filter(username);
         let (results, _res) = ldap.search(
             self.config.base_dn.as_str(),
             self.config.scope.clone().into(),
-            format!(
-                "(&({}={}){})",
-                ldap_escape(&self.config.login_attribute),
-                ldap_escape(username),
-                self.config.filter
-            ).as_str(),
+            filter.as_str(),
             attrs,
         ).await?.success()?;
-        ldap.unbind().await?;
 
         if results.is_empty() {
-            bail!("no users found");
+            bail!("no users found with filter '{}'", filter);
         }
 
         let user = SearchEntry::construct(results[0].clone());
 
+        // verify credentials by rebinding as the found user,
+        // before unbind: unbind terminates the connection
         ldap.simple_bind(
             user.dn.as_str(),
             password,
@@ -96,5 +113,42 @@ impl AuthBackend for Ldap {
                 additional_data: None,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend(filter: &str) -> Ldap {
+        Ldap {
+            config: ldap::Ldap {
+                filter: filter.to_string(),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[test]
+    fn filter_is_combined_with_login_attribute() {
+        assert_eq!(
+            backend("(objectClass=inetOrgPerson)").search_filter("alice"),
+            "(&(uid=alice)(objectClass=inetOrgPerson))",
+        );
+    }
+
+    #[test]
+    fn empty_filter_matches_login_attribute_only() {
+        assert_eq!(backend("").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("  ").search_filter("alice"), "(uid=alice)");
+        assert_eq!(backend("()").search_filter("alice"), "(uid=alice)");
+    }
+
+    #[test]
+    fn username_is_escaped() {
+        assert_eq!(
+            backend("").search_filter("a*)(uid=*"),
+            "(uid=a\\2a\\29\\28uid=\\2a)",
+        );
     }
 }

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -44,6 +44,10 @@ impl Ldap {
 
 #[async_trait]
 impl AuthBackend for Ldap {
+    fn validate_config(&self) -> Result<()> {
+        self.config.validate()
+    }
+
     fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }

--- a/src/auth_backend/ldap.rs
+++ b/src/auth_backend/ldap.rs
@@ -8,6 +8,14 @@ use crate::config::ldap;
 
 const CN_ATTR: &str = "CN";
 
+// ldap attribute names are case-insensitive (RFC 4512), but servers return
+// them in their own canonical casing, e.g. openldap returns 'cn' for 'CN'
+fn get_attr_ci<'a>(attrs: &'a std::collections::HashMap<String, Vec<String>>, name: &str) -> Option<&'a Vec<String>> {
+    attrs.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v)
+}
+
 pub struct Ldap {
     pub(crate) config: ldap::Ldap,
 }
@@ -55,7 +63,7 @@ impl AuthBackend for Ldap {
             self.config.password.as_str(),
         ).await?.success()?;
 
-        let mut attrs = vec![CN_ATTR];
+        let mut attrs = vec![CN_ATTR, self.config.login_attribute.as_str()];
         if let Some(k) = &self.config.database_attribute {
             attrs.push(k);
         }
@@ -86,20 +94,20 @@ impl AuthBackend for Ldap {
         ).await?.success()?;
         ldap.unbind().await?;
 
-        let cn = user.attrs.get(CN_ATTR)
+        let cn = get_attr_ci(&user.attrs, CN_ATTR)
             .ok_or(anyhow!("CN attribute not found"))?;
-        let id = user.attrs.get(&self.config.login_attribute)
+        let id = get_attr_ci(&user.attrs, &self.config.login_attribute)
             .ok_or(anyhow!("login attribute '{}' not found", &self.config.login_attribute))?;
 
         let mut db_location = None;
         let mut keyfile_location = None;
         if let Some(key) = &self.config.database_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 db_location = Some(v[0].clone());
             }
         }
         if let Some(key) = &self.config.keyfile_attribute {
-            if let Some(v) = user.attrs.get(key) {
+            if let Some(v) = get_attr_ci(&user.attrs, key) {
                 keyfile_location = Some(v[0].clone());
             }
         }
@@ -142,6 +150,17 @@ mod tests {
         assert_eq!(backend("").search_filter("alice"), "(uid=alice)");
         assert_eq!(backend("  ").search_filter("alice"), "(uid=alice)");
         assert_eq!(backend("()").search_filter("alice"), "(uid=alice)");
+    }
+
+    #[test]
+    fn attribute_lookup_is_case_insensitive() {
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("cn".to_string(), vec!["Test User".to_string()]);
+        attrs.insert("uID".to_string(), vec!["testuser".to_string()]);
+
+        assert_eq!(get_attr_ci(&attrs, "CN").unwrap()[0], "Test User");
+        assert_eq!(get_attr_ci(&attrs, "uid").unwrap()[0], "testuser");
+        assert!(get_attr_ci(&attrs, "mail").is_none());
     }
 
     #[test]

--- a/src/auth_backend/none.rs
+++ b/src/auth_backend/none.rs
@@ -7,7 +7,7 @@ pub struct None;
 
 #[async_trait]
 impl AuthBackend for None {
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::None)
     }
 

--- a/src/auth_backend/oidc.rs
+++ b/src/auth_backend/oidc.rs
@@ -1,7 +1,10 @@
 use std::str::FromStr;
 use std::string::ToString;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Result};
+use log::warn;
+use tokio::sync::RwLock;
 use async_trait::async_trait;
 use constant_time_eq::constant_time_eq;
 use openidconnect::{
@@ -108,6 +111,29 @@ pub struct Oidc {
     pub(crate) config: oidc::Oidc,
 }
 
+// how long provider metadata (incl. the JWKS) is served from cache
+// before it is re-fetched on the next use
+const METADATA_TTL: Duration = Duration::from_secs(10 * 60);
+
+// lazily populated, periodically refreshed provider metadata.
+// fetching at every use would hammer the provider, caching forever breaks
+// logins when the provider rotates its signing keys or was down at startup.
+#[derive(Default)]
+pub struct MetadataCache {
+    lock: RwLock<Option<CachedMetadata>>,
+}
+
+struct CachedMetadata {
+    metadata: ProviderMetadataWithLogout,
+    fetched: Instant,
+}
+
+impl CachedMetadata {
+    fn is_fresh(&self) -> bool {
+        self.fetched.elapsed() < METADATA_TTL
+    }
+}
+
 impl Oidc {
     pub fn new(config: &Config) -> Self {
         Self {
@@ -115,9 +141,7 @@ impl Oidc {
         }
     }
 
-    fn get_client(&self, host: &str, cache: &AuthCache) -> Result<OidcClient> {
-        let provider_metadata = Self::get_metadata(cache)?;
-
+    fn get_client(&self, host: &str, provider_metadata: ProviderMetadataWithLogout) -> Result<OidcClient> {
         let client: OidcClient = Client::new(
             ClientId::new(self.config.client_id.clone()),
             Some(ClientSecret::new(self.config.client_secret.clone())),
@@ -134,10 +158,50 @@ impl Oidc {
         Ok(client)
     }
 
-    fn get_metadata(cache: &AuthCache) -> Result<&ProviderMetadataWithLogout> {
-        match cache.downcast_ref::<ProviderMetadataWithLogout>() {
-            Some(v) => Ok(v),
-            None => bail!("failed to retrieve provider metadata from cache"),
+    async fn get_metadata(&self, cache: &AuthCache, force_refresh: bool) -> Result<ProviderMetadataWithLogout> {
+        let cache = match cache.downcast_ref::<MetadataCache>() {
+            Some(v) => v,
+            None => bail!("failed to retrieve provider metadata cache"),
+        };
+
+        if !force_refresh {
+            if let Some(cached) = cache.lock.read().await.as_ref() {
+                if cached.is_fresh() {
+                    return Ok(cached.metadata.clone());
+                }
+            }
+        }
+
+        let mut guard = cache.lock.write().await;
+        // another task may have refreshed while we waited for the write lock
+        if !force_refresh {
+            if let Some(cached) = guard.as_ref() {
+                if cached.is_fresh() {
+                    return Ok(cached.metadata.clone());
+                }
+            }
+        }
+
+        match ProviderMetadataWithLogout::discover_async(
+            // issuer presence is enforced by validate_config at startup
+            IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
+            async_http_client,
+        ).await {
+            Ok(metadata) => {
+                *guard = Some(CachedMetadata {
+                    metadata: metadata.clone(),
+                    fetched: Instant::now(),
+                });
+                Ok(metadata)
+            }
+            Err(err) => {
+                // keep serving the stale copy if the provider is temporarily unreachable
+                if let Some(cached) = guard.as_ref() {
+                    warn!("OIDC provider metadata refresh failed, serving cached copy: {}", err);
+                    return Ok(cached.metadata.clone());
+                }
+                Err(err.into())
+            }
         }
     }
 }
@@ -149,18 +213,20 @@ impl AuthBackend for Oidc {
     }
 
     async fn init(&self) -> Result<AuthCache> {
-        Ok(
-            Box::new(
-                ProviderMetadataWithLogout::discover_async(
-                    IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
-                    async_http_client,
-                ).await?
-            )
-        )
+        let cache: AuthCache = Box::new(MetadataCache::default());
+
+        // best-effort warm-up: an unreachable provider must not prevent
+        // startup, metadata is (re)fetched lazily when a login needs it
+        if let Err(err) = self.get_metadata(&cache, false).await {
+            warn!("OIDC provider discovery failed at startup (will retry on demand): {}", err);
+        }
+
+        Ok(cache)
     }
 
-    fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType> {
-        let client = self.get_client(host, cache)?;
+    async fn get_login_type(&self, host: &str, cache: &AuthCache) -> Result<LoginType> {
+        let metadata = self.get_metadata(cache, false).await?;
+        let client = self.get_client(host, metadata)?;
 
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
@@ -190,14 +256,14 @@ impl AuthBackend for Oidc {
         )
     }
 
-    fn get_logout_type(&self, user_info: &UserInfo, _host: &str, _cache: &AuthCache) -> Result<LogoutType> {
-        let provider_metadata = Self::get_metadata(_cache)?;
+    async fn get_logout_type(&self, user_info: &UserInfo, host: &str, cache: &AuthCache) -> Result<LogoutType> {
+        let provider_metadata = self.get_metadata(cache, false).await?;
         let logout_endpoint = provider_metadata.additional_metadata().end_session_endpoint.
             clone().ok_or(anyhow!("no session endpoint defined"))?;
 
         let mut logout_request = LogoutRequest::from(logout_endpoint)
             .set_post_logout_redirect_uri(
-                PostLogoutRedirectUrl::new(_host.to_string())?
+                PostLogoutRedirectUrl::new(host.to_string())?
             )
             .set_client_id(ClientId::new(self.config.client_id.clone()));
 
@@ -229,7 +295,8 @@ impl AuthBackend for Oidc {
             bail!("invalid csrf token (state)");
         }
 
-        let client = self.get_client(host, cache)?;
+        let metadata = self.get_metadata(cache, false).await?;
+        let client = self.get_client(host, metadata)?;
         let token_response = client
             .exchange_code(AuthorizationCode::new(oidc_params.code))
             .set_pkce_verifier(PkceCodeVerifier::new(state.pkce))
@@ -240,7 +307,20 @@ impl AuthBackend for Oidc {
             .id_token()
             .ok_or(anyhow!("server did not return an ID token"))?;
 
-        let claims = id_token.claims(&client.id_token_verifier(), &Nonce::new(state.nonce))?;
+        let nonce = Nonce::new(state.nonce);
+        // declared here so the retry's claims may borrow from it below
+        let refreshed_client;
+        let claims = match id_token.claims(&client.id_token_verifier(), &nonce) {
+            Ok(claims) => claims,
+            Err(err) => {
+                // the provider may have rotated its signing keys since the
+                // metadata was cached: refresh once and retry
+                warn!("ID token verification failed, refreshing provider metadata: {}", err);
+                let metadata = self.get_metadata(cache, true).await?;
+                refreshed_client = self.get_client(host, metadata)?;
+                id_token.claims(&refreshed_client.id_token_verifier(), &nonce)?
+            }
+        };
 
         if let Some(expected_access_token_hash) = claims.access_token_hash() {
             let actual_access_token_hash = AccessTokenHash::from_token(
@@ -274,5 +354,59 @@ impl AuthBackend for Oidc {
                 additional_data,
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use url::Url;
+
+    use super::*;
+
+    fn backend(issuer: &str) -> Oidc {
+        let mut config = Config::default();
+        config.oidc.issuer = Some(Url::from_str(issuer).unwrap());
+        config.oidc.client_id = "test-client".to_string();
+        config.oidc.client_secret = "test-secret".to_string();
+        Oidc::new(&config)
+    }
+
+    #[tokio::test]
+    async fn discovery_is_lazy_and_recovers() {
+        let mut server = mockito::Server::new_async().await;
+        let issuer = format!("{}/", server.url());
+        let oidc = backend(&issuer);
+
+        // provider is 'down' (no mocks registered): init must still succeed,
+        // login attempts surface the error per request
+        let cache = oidc.init().await.unwrap();
+        assert!(oidc.get_login_type("http://localhost:8080", &cache).await.is_err());
+
+        // provider comes up: the next login attempt must succeed
+        // without any re-initialization
+        let discovery = json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{}auth", issuer),
+            "token_endpoint": format!("{}token", issuer),
+            "jwks_uri": format!("{}jwks", issuer),
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        });
+        server.mock("GET", "/.well-known/openid-configuration")
+            .with_header("content-type", "application/json")
+            .with_body(discovery.to_string())
+            .create_async().await;
+        server.mock("GET", "/jwks")
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"keys":[]}"#)
+            .create_async().await;
+
+        let login_type = oidc.get_login_type("http://localhost:8080", &cache).await.unwrap();
+        match login_type {
+            LoginType::Redirect { url, .. } => assert!(url.as_str().starts_with(&format!("{}auth", issuer))),
+            _ => panic!("expected redirect login type"),
+        }
     }
 }

--- a/src/auth_backend/oidc.rs
+++ b/src/auth_backend/oidc.rs
@@ -40,6 +40,7 @@ use openidconnect::core::{
     CoreGenderClaim,
     CoreIdToken,
     CoreJsonWebKey,
+    CoreJsonWebKeySet,
     CoreJsonWebKeyType,
     CoreJsonWebKeyUse,
     CoreJweContentEncryptionAlgorithm,
@@ -50,6 +51,7 @@ use openidconnect::core::{
     CoreTokenType,
 };
 use openidconnect::reqwest::async_http_client;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 
 use crate::auth_backend::{AuthBackend, AuthCache, LoginType, LogoutType, ROUTE_CALLBACK_USER_AUTH, UserInfo};
@@ -109,6 +111,7 @@ struct OidcParams {
 
 pub struct Oidc {
     pub(crate) config: oidc::Oidc,
+    http_client: HttpClient,
 }
 
 // how long provider metadata (incl. the JWKS) is served from cache
@@ -138,6 +141,7 @@ impl Oidc {
     pub fn new(config: &Config) -> Self {
         Self {
             config: config.oidc.clone(),
+            http_client: HttpClient::new(),
         }
     }
 
@@ -156,6 +160,70 @@ impl Oidc {
             )?
         );
         Ok(client)
+    }
+
+    async fn fetch_metadata_from_url(&self, url: &str) -> Result<ProviderMetadataWithLogout> {
+        let body = self.http_client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        let body = self.rewrite_server_endpoints(body, url)?;
+        let metadata: ProviderMetadataWithLogout = serde_json::from_str(&body)?;
+
+        // openidconnect marks the JWKS field #[serde(skip)], so raw deserialization
+        // leaves it empty. Fetch the JWKS separately from the (already-rewritten) URI.
+        let jwks_body = self.http_client
+            .get(metadata.jwks_uri().url().as_str())
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        let jwks: CoreJsonWebKeySet = serde_json::from_str(&jwks_body)?;
+        Ok(metadata.set_jwks(jwks))
+    }
+
+    // In container setups where discovery_url differs from issuer (e.g. internal
+    // http://keycloak:8180 vs external http://localhost:8180), Keycloak's --hostname
+    // flag causes it to return all endpoint URLs with the external hostname even when
+    // the discovery doc is fetched from the internal URL. Rewrite the server-to-server
+    // endpoints (token, jwks, userinfo) to use the internal host so the app can reach
+    // them, while leaving browser-facing URLs (authorization_endpoint,
+    // end_session_endpoint) pointing at the external host so redirects still work.
+    fn rewrite_server_endpoints(&self, body: String, discovery_url: &str) -> Result<String> {
+        let issuer = match &self.config.issuer {
+            Some(u) => u,
+            None => return Ok(body),
+        };
+
+        let discovery_origin = url_origin(discovery_url);
+        let issuer_origin = url_origin(issuer.as_str());
+
+        if discovery_origin == issuer_origin || discovery_origin.is_empty() || issuer_origin.is_empty() {
+            return Ok(body);
+        }
+
+        let mut json: serde_json::Value = serde_json::from_str(&body)?;
+        for field in &[
+            "token_endpoint",
+            "jwks_uri",
+            "userinfo_endpoint",
+            "introspection_endpoint",
+            "revocation_endpoint",
+            "device_authorization_endpoint",
+        ] {
+            if let Some(val) = json.get_mut(*field) {
+                if let Some(url_str) = val.as_str() {
+                    *val = serde_json::Value::String(
+                        url_str.replacen(&issuer_origin, &discovery_origin, 1),
+                    );
+                }
+            }
+        }
+        Ok(serde_json::to_string(&json)?)
     }
 
     async fn get_metadata(&self, cache: &AuthCache, force_refresh: bool) -> Result<ProviderMetadataWithLogout> {
@@ -182,11 +250,19 @@ impl Oidc {
             }
         }
 
-        match ProviderMetadataWithLogout::discover_async(
-            // issuer presence is enforced by validate_config at startup
-            IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
-            async_http_client,
-        ).await {
+        let result = match &self.config.discovery_url {
+            // discovery_url bypasses the openidconnect issuer-must-match check so the
+            // app can fetch metadata from an internal URL (e.g. http://keycloak:8180)
+            // while the issuer in tokens is an external URL (e.g. http://localhost:8180).
+            Some(url) => self.fetch_metadata_from_url(url.as_str()).await.map_err(Into::into),
+            None => ProviderMetadataWithLogout::discover_async(
+                // issuer presence is enforced by validate_config at startup
+                IssuerUrl::from_url(self.config.issuer.clone().unwrap()),
+                async_http_client,
+            ).await.map_err(Into::into),
+        };
+
+        match result {
             Ok(metadata) => {
                 *guard = Some(CachedMetadata {
                     metadata: metadata.clone(),
@@ -200,7 +276,7 @@ impl Oidc {
                     warn!("OIDC provider metadata refresh failed, serving cached copy: {}", err);
                     return Ok(cached.metadata.clone());
                 }
-                Err(err.into())
+                Err(err)
             }
         }
     }
@@ -355,6 +431,20 @@ impl AuthBackend for Oidc {
             }
         )
     }
+}
+
+fn url_origin(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .map(|u| {
+            let mut s = format!("{}://{}", u.scheme(), u.host_str().unwrap_or(""));
+            if let Some(port) = u.port() {
+                s.push(':');
+                s.push_str(&port.to_string());
+            }
+            s
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/src/auth_backend/test.rs
+++ b/src/auth_backend/test.rs
@@ -7,7 +7,7 @@ pub struct Test;
 
 #[async_trait]
 impl AuthBackend for Test {
-    fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
+    async fn get_login_type(&self, _: &str, _: &AuthCache) -> Result<LoginType> {
         Ok(LoginType::Mask)
     }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -35,6 +35,9 @@ pub struct Config {
     pub session_lifetime: Duration,
     #[serde(with = "SameSiteDef")]
     pub cookie_samesite: cookie::SameSite,
+    // only enable behind a reverse proxy: forwarding headers are
+    // client-controlled and would let rate limiting be evaded
+    pub trust_proxy_headers: bool,
     pub search: Search,
     #[serde(alias = "LDAP", alias = "Ldap")]
     pub ldap: Ldap,
@@ -63,6 +66,7 @@ impl Default for Config {
             // 1 hour
             session_lifetime: Duration::from_secs(60 * 60),
             cookie_samesite: cookie::SameSite::Strict,
+            trust_proxy_headers: false,
             search: Default::default(),
             ldap: Default::default(),
             oidc: Default::default(),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -38,6 +38,11 @@ pub struct Config {
     // only enable behind a reverse proxy: forwarding headers are
     // client-controlled and would let rate limiting be evaded
     pub trust_proxy_headers: bool,
+    // use the linux kernel keyring for session key storage (linux only).
+    // set to false if your container runtime blocks keyctl/add_key/request_key
+    // (e.g. docker desktop on macos without a custom seccomp profile).
+    // ignored on non-linux platforms, which always use the in-memory store.
+    pub use_keyring: bool,
     pub search: Search,
     #[serde(alias = "LDAP", alias = "Ldap")]
     pub ldap: Ldap,
@@ -67,6 +72,7 @@ impl Default for Config {
             session_lifetime: Duration::from_secs(60 * 60),
             cookie_samesite: cookie::SameSite::Strict,
             trust_proxy_headers: false,
+            use_keyring: true,
             search: Default::default(),
             ldap: Default::default(),
             oidc: Default::default(),

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -1,4 +1,6 @@
+use anyhow::{bail, Result};
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Clone, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -33,6 +35,28 @@ pub struct Ldap {
     pub keyfile_attribute: Option<String>,
 }
 
+impl Ldap {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.uri.trim().is_empty() {
+            bail!("LDAP: uri must be specified");
+        }
+        match Url::parse(&self.uri) {
+            Ok(url) => match url.scheme() {
+                "ldap" | "ldaps" | "ldapi" => {}
+                scheme => bail!("LDAP: unsupported uri scheme '{}', expected ldap, ldaps or ldapi", scheme),
+            },
+            Err(err) => bail!("LDAP: invalid uri '{}': {}", self.uri, err),
+        }
+        if self.base_dn.trim().is_empty() {
+            bail!("LDAP: base_dn must be specified");
+        }
+        if self.login_attribute.trim().is_empty() {
+            bail!("LDAP: login_attribute must be specified");
+        }
+        Ok(())
+    }
+}
+
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
@@ -46,5 +70,49 @@ impl Default for Ldap {
             database_attribute: None,
             keyfile_attribute: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> Ldap {
+        Ldap {
+            base_dn: "ou=users,dc=example,dc=org".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        assert!(valid().validate().is_ok());
+
+        let mut ldaps = valid();
+        ldaps.uri = "ldaps://example.org:636".to_string();
+        assert!(ldaps.validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_config_fails() {
+        let mut c = valid();
+        c.uri = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "http://example.org".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.uri = "not a url".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.base_dn = "".to_string();
+        assert!(c.validate().is_err());
+
+        let mut c = valid();
+        c.login_attribute = " ".to_string();
+        assert!(c.validate().is_err());
     }
 }

--- a/src/config/ldap.rs
+++ b/src/config/ldap.rs
@@ -36,10 +36,10 @@ pub struct Ldap {
 impl Default for Ldap {
     fn default() -> Self {
         Ldap {
-            uri: "ldap://localhost:339".to_string(),
+            uri: "ldap://localhost:389".to_string(),
             scope: Scope::default(),
             base_dn: "".to_string(),
-            filter: "()".to_string(),
+            filter: "".to_string(),
             login_attribute: "uid".to_string(),
             bind: "".to_string(),
             password: "".to_string(),

--- a/src/config/oidc.rs
+++ b/src/config/oidc.rs
@@ -7,6 +7,12 @@ use url::Url;
 #[serde(default)]
 pub struct Oidc {
     pub issuer: Option<Url>,
+    /// Override the URL used to fetch OIDC provider metadata.
+    /// Useful in Docker/container setups where the app reaches the provider
+    /// via an internal hostname (e.g. `http://keycloak:8180`) but the issuer
+    /// in tokens is an external hostname (e.g. `http://localhost:8180`).
+    /// When unset, metadata is fetched from `<issuer>/.well-known/openid-configuration`.
+    pub discovery_url: Option<Url>,
     pub client_id: String,
     pub client_secret: String,
     pub scopes: Vec<String>,
@@ -17,6 +23,7 @@ impl Default for Oidc {
     fn default() -> Self {
         Oidc {
             issuer: None,
+            discovery_url: None,
             client_id: "".to_string(),
             client_secret: "".to_string(),
             scopes: vec![],

--- a/src/db_backend/filesystem.rs
+++ b/src/db_backend/filesystem.rs
@@ -65,9 +65,10 @@ impl DbBackend for Filesystem {
             path = Path::new(db_location);
         }
 
+        // File::open opens read-only, writes would fail with EBADF
         Ok(
             (
-                Box::pin(File::open(
+                Box::pin(File::create(
                     path
                 ).await?),
                 None
@@ -89,5 +90,37 @@ impl Filesystem {
         Self {
             config: config.filesystem.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn write_roundtrip() {
+        let path = std::env::temp_dir().join("k4w-filesystem-write-test.kdbx");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        let mut config = Config::default();
+        config.filesystem.db_location = path.clone();
+        let mut backend = Filesystem::new(&config);
+
+        let data = b"some database content";
+        {
+            let (mut writer, rx) = backend.get_db_write(&UserInfo::default()).await.unwrap();
+            writer.write_all(data).await.unwrap();
+            writer.shutdown().await.unwrap();
+            assert!(rx.is_none());
+        }
+
+        let mut reader = backend.get_db_read(&UserInfo::default()).await.unwrap();
+        let mut read_back = vec![];
+        reader.read_to_end(&mut read_back).await.unwrap();
+        assert_eq!(read_back, data);
+
+        let _ = tokio::fs::remove_file(&path).await;
     }
 }

--- a/src/db_backend/http.rs
+++ b/src/db_backend/http.rs
@@ -21,6 +21,7 @@ use crate::db_backend::DbBackend;
 
 pub struct Http {
     pub config: http::Http,
+    client: Client,
 }
 
 #[async_trait]
@@ -105,7 +106,9 @@ impl DbBackend for Http {
 impl Http {
     pub fn new(config: &Config) -> Self {
         Self {
-            config: config.http.clone()
+            config: config.http.clone(),
+            // reuse one client for connection pooling and tls session reuse
+            client: Client::new(),
         }
     }
 
@@ -134,9 +137,7 @@ impl Http {
     }
 
     fn get_request(&self, method: Method, url: Url) -> Result<RequestBuilder> {
-        let mut req = Client::builder()
-            .build()?.
-            request(method, url);
+        let mut req = self.client.request(method, url);
 
         if let Some(cred) = &self.config.credentials {
             req = req.basic_auth(cred.username.clone(), cred.password.clone());

--- a/src/db_backend/http.rs
+++ b/src/db_backend/http.rs
@@ -32,7 +32,7 @@ impl DbBackend for Http {
     async fn get_db_read(&self, user_info: &UserInfo) -> Result<Pin<Box<dyn AsyncRead + '_>>> {
         let url = self.get_db_url(user_info)?;
 
-        let response = self.get_request(Method::GET, url)?.send().await?;
+        let response = self.get_request(Method::GET, url)?.send().await?.error_for_status()?;
         Ok(
             Self::get_boxed_response(response)
         )
@@ -62,7 +62,7 @@ impl DbBackend for Http {
             Err(err) => return Some(Err(err))
         };
 
-        match request.send().await {
+        match request.send().await.and_then(|r| r.error_for_status()) {
             Ok(response) => {
                 Some(Ok(Self::get_boxed_response(response)))
             }
@@ -81,7 +81,7 @@ impl DbBackend for Http {
 
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            tx.send(match req.send().await {
+            tx.send(match req.send().await.and_then(|r| r.error_for_status()) {
                 Ok(_) => Ok(()),
                 Err(err) => Err(err).map_err(Error::new),
             }) // ignore failed send
@@ -216,6 +216,38 @@ mod tests {
     #[tokio::test]
     async fn write_fail() {
         let res = write_http(Url::from_str("http://0.0.0.0").unwrap()).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("GET", "/")
+            .with_body("<html>not found</html>")
+            .with_status(404)
+            .create_async().await;
+
+        let mut config = Config::default();
+        config.http.database_url = Some(Url::from_str(&server.url()).unwrap());
+        let http = Http::new(&config);
+        let res = http.get_db_read(&UserInfo::default()).await;
+
+        mock.assert_async().await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn write_fail_on_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("PUT", "/")
+            .with_status(500)
+            .create_async().await;
+
+        let res = write_http(Url::from_str(&server.url()).unwrap()).await;
+
+        mock.assert_async().await;
 
         assert!(res.is_err());
     }

--- a/src/keepass/db_cache.rs
+++ b/src/keepass/db_cache.rs
@@ -43,15 +43,19 @@ impl Deref for DbCache {
 
 impl DbCache {
     pub async fn store(&self, session: &Session, enc_db: Encrypted) -> Result<()> {
-        self.write().await
-            .insert(
-                self.get_user(session)?, enc_db,
-            );
+        let user = self.get_user(session)?;
+        let mut cache = self.write().await;
+
+        // evict expired entries opportunistically, so the cache
+        // doesn't grow unboundedly with inactive users
+        let now = Instant::now();
+        cache.retain(|_, enc| now < enc.expiry);
+
+        cache.insert(user, enc_db);
 
         Ok(())
     }
 
-    // TODO: expire old entries periodically
     pub async fn retrieve(&self, session: &Session, timeout: Duration) -> Result<Encrypted> {
         let user = self.get_user(session)?;
         let mut enc = self.read().await.get(user.as_str()).ok_or(anyhow!("enc db not found in store"))?.clone();
@@ -82,5 +86,35 @@ impl DbCache {
         Ok(
             session.get::<UserInfo>(SESSION_KEY_USER)?.ok_or(anyhow!("unable to retrieve user from session"))?.id
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_session::SessionExt;
+    use actix_web::test::TestRequest;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn expired_entries_are_evicted_on_store() {
+        let cache = DbCache::default();
+        let req = TestRequest::default().to_http_request();
+        let session = req.get_session();
+        session.insert(SESSION_KEY_USER, UserInfo {
+            id: "alice".to_string(),
+            ..Default::default()
+        }).unwrap();
+
+        // expired entry of an inactive user
+        let (_, expired) = Encrypted::encrypt(vec![1, 2, 3], &[], Duration::from_secs(0)).unwrap();
+        cache.write().await.insert("bob".to_string(), expired);
+
+        let (_, fresh) = Encrypted::encrypt(vec![4, 5, 6], &[], Duration::from_secs(60)).unwrap();
+        cache.store(&session, fresh).await.unwrap();
+
+        let entries = cache.read().await;
+        assert!(entries.contains_key("alice"));
+        assert!(!entries.contains_key("bob"));
     }
 }

--- a/src/keepass/encrypted.rs
+++ b/src/keepass/encrypted.rs
@@ -9,8 +9,6 @@ use zeroize::Zeroize;
 
 use crate::keepass::key::SecretKey;
 
-const LENGTH_IV: usize = 16;
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Encrypted {
     data: Vec<u8>,
@@ -20,8 +18,7 @@ pub struct Encrypted {
 }
 
 impl Encrypted {
-    pub fn encrypt(mut input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
-        input.extend([0; LENGTH_IV]);
+    pub fn encrypt(input: Vec<u8>, aad: &[u8], timeout: Duration) -> Result<(SecretKey, Encrypted)> {
         let iv = Aes256Gcm::generate_nonce(&mut thread_rng()); // 96-bits; unique per message
         let mut enc = Encrypted {
             data: input,
@@ -42,7 +39,7 @@ impl Encrypted {
         let cipher = Aes256Gcm::new(key);
         cipher.decrypt_in_place(Nonce::from_slice(&self.iv), aad, &mut self.data)?;
 
-        let v = self.data[0..self.data.len() - LENGTH_IV].to_vec();
+        let v = self.data.clone();
         self.data.zeroize();
         Ok(SecretVec::new(v))
     }

--- a/src/keepass/entry.rs
+++ b/src/keepass/entry.rs
@@ -19,6 +19,7 @@ pub struct Group {
 
 #[derive(Serialize)]
 pub struct EntryGroup {
+    pub id: Uuid,
     pub title: String,
     pub icon: Option<usize>,
     pub custom_icon_uuid: Option<Uuid>,

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -230,12 +230,6 @@ impl KeePass {
         )
     }
 
-    pub fn get_file(&self, params: &Query<File>) -> Result<Vec<u8>> {
-        let _entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
-
-        todo!()
-    }
-
     pub fn search_entries(&self, params: &Query<SearchTerm>) -> Result<EntryGroup> {
         let mut term = params.term.clone();
         if !self.config.search.allow_regex {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -373,8 +373,9 @@ mod tests {
 
         let (mut key, enc) = keepass.to_enc().unwrap();
 
-        key.store(config.db_session_timeout).unwrap();
-        let ret_key = SecretKey::retrieve(&key.key_id, config.db_session_timeout).unwrap();
+        // tests always use the in-memory store; the keyring is unavailable in most CI/test environments
+        key.store(config.db_session_timeout, false).unwrap();
+        let ret_key = SecretKey::retrieve(&key.key_id, config.db_session_timeout, false).unwrap();
 
         let dec = KeePass::from_enc(&config, ret_key, enc).unwrap();
 

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -212,6 +212,7 @@ impl KeePass {
         password: &str,
         url: &str,
         notes: &str,
+        icon: Option<usize>,
     ) -> Result<Uuid> {
         let group = Self::find_group_by_id_mut(&mut self.db.root, group_id)
             .ok_or(NotFoundError("group"))?;
@@ -224,6 +225,7 @@ impl KeePass {
         }
         entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
         entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+        entry.icon_id = icon;
 
         let uuid = entry.uuid;
         group.add_child(entry);
@@ -238,6 +240,7 @@ impl KeePass {
         password: &str,
         url: &str,
         notes: &str,
+        icon: Option<usize>,
     ) -> Result<()> {
         let entry = Self::find_entry_by_id_mut(&mut self.db.root, entry_id)
             .ok_or(NotFoundError("entry"))?;
@@ -249,6 +252,9 @@ impl KeePass {
         }
         entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
         entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+        if let Some(id) = icon {
+            entry.icon_id = Some(id);
+        }
 
         Ok(())
     }

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -322,6 +322,7 @@ impl KeePass {
         }
 
         Ok(EntryGroup {
+            id: group.uuid,
             title: group.name.clone(),
             entries,
             icon: group.icon_id,
@@ -367,6 +368,7 @@ impl KeePass {
         let entries = Self::find_entries_by_string(&self.db.root, &rgx, &self.config.search);
 
         Ok(EntryGroup {
+            id: Uuid::nil(),
             title: format!("Search results for '{}'", params.term),
             entries,
             // search icon

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -26,6 +26,19 @@ use crate::keepass::entry::{
 };
 use crate::keepass::key::SecretKey;
 
+// distinguishes missing entries/groups/icons from real server faults,
+// so handlers can return 404 instead of 500
+#[derive(Debug, Clone)]
+pub struct NotFoundError(pub &'static str);
+
+impl std::fmt::Display for NotFoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} not found", self.0)
+    }
+}
+
+impl std::error::Error for NotFoundError {}
+
 #[derive(Deserialize)]
 pub struct Id {
     pub id: Uuid,
@@ -169,7 +182,7 @@ impl KeePass {
     }
 
     pub fn get_group_entries(&self, params: &Query<Id>) -> Result<EntryGroup> {
-        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(anyhow!("group not found"))?;
+        let group = Self::find_group_by_id(&self.db.root, &params.id).ok_or(NotFoundError("group"))?;
 
         let mut entries = Vec::with_capacity(group.children.len());
         for node in &group.children {
@@ -202,13 +215,13 @@ impl KeePass {
     }
 
     pub fn get_entry(&self, params: &Query<Id>) -> Result<Entry> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.id).ok_or(NotFoundError("entry"))?;
 
         Ok(entry.into())
     }
 
     pub fn get_protected(&self, params: &Query<Protected>) -> Result<SecretString> {
-        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(anyhow!("entry not found"))?;
+        let entry = Self::find_entry_by_id(&self.db.root, &params.entry_id).ok_or(NotFoundError("entry"))?;
 
         let field = match params.name.as_str() {
             "password" => entry.fields.get("Password").cloned(),
@@ -220,7 +233,7 @@ impl KeePass {
                 Value::Protected(p) => p,
                 _ => bail!("not a protected field"),
             },
-            None => bail!("field not found"),
+            None => return Err(NotFoundError("field").into()),
         };
 
         Ok(
@@ -255,7 +268,7 @@ impl KeePass {
             }
         }
 
-        bail!("icon not found")
+        Err(NotFoundError("icon").into())
     }
 
     pub(crate) fn find_all_groups(group: &keepass::db::Group) -> Group {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -5,7 +5,8 @@ use base64;
 use base64::Engine;
 use base64::engine::general_purpose;
 use keepass::{Database, DatabaseKey};
-use keepass::db::{Icon, Node, Value};
+use keepass::config::DatabaseConfig;
+use keepass::db::{Entry as KpEntry, Group as KpGroup, Icon, Node, Value};
 use regex::Regex;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
@@ -90,27 +91,62 @@ impl KeePass {
         Encrypted::encrypt(ser_db, &[], self.config.db_session_timeout)
     }
 
-    pub async fn from_backend(config: &Config, db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<Self> {
+    pub async fn from_backend(config: &Config, db_backend: &mut dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<Self> {
         let db_key = Self::db_key_from_params(db_backend, params, user_info).await?;
 
-        let mut reader = db_backend.get_db_read(user_info).await?;
+        // Read the database into an owned buffer. The reader (which borrows db_backend)
+        // is dropped when the async block completes, releasing the immutable borrow before
+        // we potentially need &mut db_backend to create a new database.
+        let load_result: Result<Vec<u8>> = async {
+            let mut reader = db_backend.get_db_read(user_info).await?;
+            let mut buf = vec![];
+            reader.read_to_end(&mut buf).await?;
+            Ok(buf)
+        }.await;
 
-        // bridge sync and async by caching the whole file in memory for now
-        let mut buf = vec![];
-        reader.read_to_end(&mut buf).await?;
+        let buf = match load_result {
+            Ok(buf) => buf,
+            Err(err) => {
+                // No database at the configured path yet — create a new empty one.
+                if err.downcast_ref::<std::io::Error>()
+                    .map(|e| e.kind() == std::io::ErrorKind::NotFound)
+                    .unwrap_or(false)
+                {
+                    return Self::create_new(config, db_backend, db_key, user_info).await;
+                }
+                return Err(err);
+            }
+        };
 
         let db = tokio::task::spawn_blocking(move || {
+            let mut buf = buf;
             let db = Database::open(&mut buf.as_slice(), db_key);
             buf.zeroize();
             db
         }).await??;
 
-        Ok(
-            KeePass {
-                config: config.clone(),
-                db,
-            }
-        )
+        Ok(KeePass { config: config.clone(), db })
+    }
+
+    async fn create_new(config: &Config, db_backend: &mut dyn DbBackend, db_key: DatabaseKey, user_info: &UserInfo) -> Result<Self> {
+        let db = Database::new(DatabaseConfig::default());
+
+        let mut buf: Vec<u8> = vec![];
+        let (result, mut buf, db) = tokio::task::spawn_blocking(move || {
+            let r = db.save(&mut buf, db_key);
+            (r, buf, db)
+        }).await?;
+        result.map_err(|e| anyhow::anyhow!("failed to initialise new database: {}", e))?;
+
+        let (mut writer, rx) = db_backend.get_db_write(user_info).await?;
+        writer.write_all(&buf).await?;
+        buf.zeroize();
+        writer.shutdown().await?;
+        if let Some(rx) = rx {
+            rx.await??;
+        }
+
+        Ok(KeePass { config: config.clone(), db })
     }
 
     #[allow(dead_code)]
@@ -135,6 +171,10 @@ impl KeePass {
         }
 
         Ok(())
+    }
+
+    pub(crate) async fn db_key_from_params_pub(db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<DatabaseKey> {
+        Self::db_key_from_params(db_backend, params, user_info).await
     }
 
     async fn db_key_from_params(db_backend: &dyn DbBackend, params: &DbLogin, user_info: &UserInfo) -> Result<DatabaseKey> {
@@ -163,6 +203,81 @@ impl KeePass {
         Ok(db_key)
     }
 
+
+    pub fn create_entry(
+        &mut self,
+        group_id: &Uuid,
+        title: &str,
+        username: &str,
+        password: &str,
+        url: &str,
+        notes: &str,
+    ) -> Result<Uuid> {
+        let group = Self::find_group_by_id_mut(&mut self.db.root, group_id)
+            .ok_or(NotFoundError("group"))?;
+
+        let mut entry = KpEntry::new();
+        entry.fields.insert("Title".to_string(), Value::Unprotected(title.to_string()));
+        entry.fields.insert("UserName".to_string(), Value::Unprotected(username.to_string()));
+        if !password.is_empty() {
+            entry.fields.insert("Password".to_string(), Value::Protected(password.as_bytes().into()));
+        }
+        entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
+        entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+
+        let uuid = entry.uuid;
+        group.add_child(entry);
+        Ok(uuid)
+    }
+
+    pub fn update_entry(
+        &mut self,
+        entry_id: &Uuid,
+        title: &str,
+        username: &str,
+        password: &str,
+        url: &str,
+        notes: &str,
+    ) -> Result<()> {
+        let entry = Self::find_entry_by_id_mut(&mut self.db.root, entry_id)
+            .ok_or(NotFoundError("entry"))?;
+
+        entry.fields.insert("Title".to_string(), Value::Unprotected(title.to_string()));
+        entry.fields.insert("UserName".to_string(), Value::Unprotected(username.to_string()));
+        if !password.is_empty() {
+            entry.fields.insert("Password".to_string(), Value::Protected(password.as_bytes().into()));
+        }
+        entry.fields.insert("URL".to_string(), Value::Unprotected(url.to_string()));
+        entry.fields.insert("Notes".to_string(), Value::Unprotected(notes.to_string()));
+
+        Ok(())
+    }
+
+    pub fn delete_entry(&mut self, entry_id: &Uuid) -> Result<()> {
+        if !Self::remove_entry_from_group(&mut self.db.root, entry_id) {
+            return Err(NotFoundError("entry").into());
+        }
+        Ok(())
+    }
+
+    pub async fn to_backend_with_key(self, db_backend: &mut dyn DbBackend, db_key: DatabaseKey, user_info: &UserInfo) -> Result<()> {
+        let mut buf: Vec<u8> = vec![];
+        let (result, mut buf) = tokio::task::spawn_blocking(move || {
+            let r = self.db.save(&mut buf, db_key);
+            (r, buf)
+        }).await?;
+        result.map_err(|e| anyhow::anyhow!("failed to save database: {}", e))?;
+
+        let (mut writer, rx) = db_backend.get_db_write(user_info).await?;
+        writer.write_all(&buf).await?;
+        buf.zeroize();
+        writer.shutdown().await?;
+        if let Some(rx) = rx {
+            rx.await??;
+        }
+
+        Ok(())
+    }
 
     pub fn get_groups(&self) -> Result<(Group, Option<Uuid>)> {
         let mut last_selected = self.db.meta.last_selected_group;
@@ -322,6 +437,59 @@ impl KeePass {
         }
 
         None
+    }
+
+    fn find_group_by_id_mut<'a>(group: &'a mut KpGroup, id: &Uuid) -> Option<&'a mut KpGroup> {
+        if &group.uuid == id {
+            return Some(group);
+        }
+        for node in &mut group.children {
+            if let Node::Group(g) = node {
+                let found = Self::find_group_by_id_mut(g, id);
+                if found.is_some() {
+                    return found;
+                }
+            }
+        }
+        None
+    }
+
+    fn find_entry_by_id_mut<'a>(group: &'a mut KpGroup, id: &Uuid) -> Option<&'a mut KpEntry> {
+        for node in &mut group.children {
+            match node {
+                Node::Group(g) => {
+                    let found = Self::find_entry_by_id_mut(g, id);
+                    if found.is_some() {
+                        return found;
+                    }
+                }
+                Node::Entry(e) => {
+                    if &e.uuid == id {
+                        return Some(e);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn remove_entry_from_group(group: &mut KpGroup, id: &Uuid) -> bool {
+        let before = group.children.len();
+        group.children.retain(|node| match node {
+            Node::Entry(e) => &e.uuid != id,
+            _ => true,
+        });
+        if group.children.len() < before {
+            return true;
+        }
+        for node in &mut group.children {
+            if let Node::Group(g) = node {
+                if Self::remove_entry_from_group(g, id) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub(crate) fn find_entries_by_string(group: &keepass::db::Group, term: &Regex, config: &Search) -> Vec<Entry> {

--- a/src/keepass/keepass.rs
+++ b/src/keepass/keepass.rs
@@ -253,6 +253,35 @@ impl KeePass {
         Ok(())
     }
 
+    pub fn create_group(&mut self, parent_id: &Uuid, name: &str) -> Result<Uuid> {
+        // Root accepts unlimited groups. Non-root groups are capped at 2 subgroups,
+        // which also blocks nesting beyond one level below root.
+        if *parent_id != self.db.root.uuid {
+            let parent = Self::find_group_by_id(&self.db.root, parent_id)
+                .ok_or(NotFoundError("group"))?;
+            let subgroup_count = parent.children.iter()
+                .filter(|n| matches!(n, Node::Group(_)))
+                .count();
+            if subgroup_count >= 2 {
+                return Err(anyhow::anyhow!("a group may have at most 2 subgroups"));
+            }
+        }
+
+        let parent = Self::find_group_by_id_mut(&mut self.db.root, parent_id)
+            .ok_or(NotFoundError("group"))?;
+        let group = KpGroup::new(name);
+        let id = group.uuid;
+        parent.children.push(Node::Group(group));
+        Ok(id)
+    }
+
+    pub fn rename_group(&mut self, group_id: &Uuid, name: &str) -> Result<()> {
+        let group = Self::find_group_by_id_mut(&mut self.db.root, group_id)
+            .ok_or(NotFoundError("group"))?;
+        group.name = name.to_string();
+        Ok(())
+    }
+
     pub fn delete_entry(&mut self, entry_id: &Uuid) -> Result<()> {
         if !Self::remove_entry_from_group(&mut self.db.root, entry_id) {
             return Err(NotFoundError("entry").into());

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -9,13 +9,9 @@ use crate::auth::gen_token;
 
 #[cfg(target_os = "linux")]
 mod keyring;
-#[cfg(target_os = "linux")]
-use keyring as store;
 
-#[cfg(any(not(target_os = "linux"), test))]
-mod memory;
-#[cfg(not(target_os = "linux"))]
-use memory as store;
+// always compiled: used on non-linux, in tests, and when use_keyring=false on linux
+pub(super) mod memory;
 
 pub type KeyId = String;
 
@@ -38,6 +34,7 @@ pub struct SecretKey {
     pub key_id: KeyId,
     data: SecretBox<[u8]>,
     timeout: Duration,
+    use_keyring: bool,
 }
 
 impl SecretKey {
@@ -46,23 +43,26 @@ impl SecretKey {
             key_id: gen_token(ID_LENGTH),
             data: SecretBox::new(secret),
             timeout: Duration::default(),
+            use_keyring: false,
         }
     }
 
-    pub fn retrieve(key_id: &KeyId, timeout: Duration) -> Result<Self> {
-        let data = store::retrieve(key_id, timeout)?;
+    pub fn retrieve(key_id: &KeyId, timeout: Duration, use_keyring: bool) -> Result<Self> {
+        let data = Self::dispatch_retrieve(key_id, timeout, use_keyring)?;
 
         Ok(
             Self {
                 key_id: key_id.clone(),
                 data: SecretBox::new(data),
                 timeout,
+                use_keyring,
             }
         )
     }
 
-    pub fn store(&mut self, timeout: Duration) -> Result<&mut Self> {
-        store::store(&self.key_id, self.expose_secret(), timeout)?;
+    pub fn store(&mut self, timeout: Duration, use_keyring: bool) -> Result<&mut Self> {
+        self.use_keyring = use_keyring;
+        Self::dispatch_store(&self.key_id, self.expose_secret(), timeout, use_keyring)?;
 
         self.timeout = timeout;
         Ok(self)
@@ -70,9 +70,51 @@ impl SecretKey {
 
     // retrieve will fail after revoke
     pub fn revoke(&mut self) -> Result<&mut Self> {
-        store::revoke(&self.key_id)?;
+        Self::dispatch_revoke(&self.key_id, self.use_keyring)?;
 
         Ok(self)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_store(key_id: &str, secret: &[u8], timeout: Duration, use_keyring: bool) -> Result<()> {
+        if use_keyring {
+            keyring::store(key_id, secret, timeout)
+        } else {
+            memory::store(key_id, secret, timeout)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_store(key_id: &str, secret: &[u8], timeout: Duration, _use_keyring: bool) -> Result<()> {
+        memory::store(key_id, secret, timeout)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_retrieve(key_id: &str, timeout: Duration, use_keyring: bool) -> Result<Box<[u8]>> {
+        if use_keyring {
+            keyring::retrieve(key_id, timeout)
+        } else {
+            memory::retrieve(key_id, timeout)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_retrieve(key_id: &str, timeout: Duration, _use_keyring: bool) -> Result<Box<[u8]>> {
+        memory::retrieve(key_id, timeout)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn dispatch_revoke(key_id: &str, use_keyring: bool) -> Result<()> {
+        if use_keyring {
+            keyring::revoke(key_id)
+        } else {
+            memory::revoke(key_id)
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn dispatch_revoke(key_id: &str, _use_keyring: bool) -> Result<()> {
+        memory::revoke(key_id)
     }
 }
 
@@ -95,8 +137,8 @@ mod tests {
     #[test]
     fn key_roundtrip() {
         let mut key = SecretKey::new("some random string !@(as+=!#@_%$".to_string().into_bytes().into_boxed_slice());
-        key.store(Duration::from_secs(10)).unwrap();
-        let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+        key.store(Duration::from_secs(10), false).unwrap();
+        let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10), false).unwrap();
 
         assert_eq!(key.expose_secret(), data.expose_secret());
     }
@@ -106,8 +148,8 @@ mod tests {
     fn key_roundtrip_other_lengths() {
         for secret in [&b"short"[..], &[7u8; 64][..]] {
             let mut key = SecretKey::new(secret.to_vec().into_boxed_slice());
-            key.store(Duration::from_secs(10)).unwrap();
-            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+            key.store(Duration::from_secs(10), false).unwrap();
+            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10), false).unwrap();
 
             assert_eq!(key.expose_secret(), data.expose_secret());
         }

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -101,6 +101,18 @@ mod tests {
         assert_eq!(key.expose_secret(), data.expose_secret());
     }
 
+    // regression: the store must not assume a fixed secret length
+    #[test]
+    fn key_roundtrip_other_lengths() {
+        for secret in [&b"short"[..], &[7u8; 64][..]] {
+            let mut key = SecretKey::new(secret.to_vec().into_boxed_slice());
+            key.store(Duration::from_secs(10)).unwrap();
+            let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
+
+            assert_eq!(key.expose_secret(), data.expose_secret());
+        }
+    }
+
     #[test]
     fn memory_store_roundtrip_and_revoke() {
         let secret = b"0123456789abcdef0123456789abcdef";

--- a/src/keepass/key.rs
+++ b/src/keepass/key.rs
@@ -1,24 +1,44 @@
+use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::time::Duration;
 
 use anyhow::Result;
-use linux_keyutils::{Key, KeyPermissions, KeyRing, KeyRingIdentifier};
 use secrecy::{ExposeSecret, SecretBox};
 
 use crate::auth::gen_token;
+
+#[cfg(target_os = "linux")]
+mod keyring;
+#[cfg(target_os = "linux")]
+use keyring as store;
+
+#[cfg(any(not(target_os = "linux"), test))]
+mod memory;
+#[cfg(not(target_os = "linux"))]
+use memory as store;
+
+pub type KeyId = String;
+
+const ID_LENGTH: usize = 16;
+
+// returned when a key is missing, expired or revoked - the http layer
+// treats this as 'db closed' rather than a server fault
+#[derive(Debug, Clone)]
+pub struct KeyUnavailableError;
+
+impl Display for KeyUnavailableError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "key not found, expired or revoked")
+    }
+}
+
+impl std::error::Error for KeyUnavailableError {}
 
 pub struct SecretKey {
     pub key_id: KeyId,
     data: SecretBox<[u8]>,
     timeout: Duration,
 }
-
-pub type KeyId = String;
-
-
-const ID_LENGTH: usize = 16;
-const KEYRING_PERM: u32 = 0x3f000000;
-
 
 impl SecretKey {
     pub fn new(secret: Box<[u8]>) -> Self {
@@ -30,31 +50,19 @@ impl SecretKey {
     }
 
     pub fn retrieve(key_id: &KeyId, timeout: Duration) -> Result<Self> {
-        let keyr = get_keyring()?;
+        let data = store::retrieve(key_id, timeout)?;
 
-        let mut k = keyr.search(key_id.as_str())?;
-
-        // TODO: determine buffer size
-        let mut data = vec![0; 32].into_boxed_slice();
-        k.read(&mut data)?;
-
-        let key = Self {
-            key_id: key_id.clone(),
-            data: SecretBox::new(data),
-            timeout,
-        };
-
-        key.update_timeout(&mut k, timeout)?;
-
-        Ok(key)
+        Ok(
+            Self {
+                key_id: key_id.clone(),
+                data: SecretBox::new(data),
+                timeout,
+            }
+        )
     }
 
     pub fn store(&mut self, timeout: Duration) -> Result<&mut Self> {
-        let keyr = get_keyring()?;
-
-        let key = keyr.add_key(self.key_id.as_str(), self.expose_secret())?;
-        key.set_timeout(timeout.as_secs() as usize)?;
-        key.set_perms(KeyPermissions::from_u32(KEYRING_PERM))?;
+        store::store(&self.key_id, self.expose_secret(), timeout)?;
 
         self.timeout = timeout;
         Ok(self)
@@ -62,17 +70,9 @@ impl SecretKey {
 
     // retrieve will fail after revoke
     pub fn revoke(&mut self) -> Result<&mut Self> {
-        let keyr = get_keyring()?;
-
-        let k = keyr.search(self.key_id.as_str())?;
-
-        k.revoke()?;
+        store::revoke(&self.key_id)?;
 
         Ok(self)
-    }
-
-    fn update_timeout(&self, key: &mut Key, timeout: Duration) -> Result<()> {
-        Ok(key.set_timeout(timeout.as_secs() as usize)?)
     }
 }
 
@@ -84,19 +84,13 @@ impl Deref for SecretKey {
     }
 }
 
-fn get_keyring() -> Result<KeyRing> {
-    // TODO: Make other keyrings available
-    // TODO: Investigate why key in Process keyring doesn't persist
-    Ok(KeyRing::from_special_id(KeyRingIdentifier::Session, false)?)
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use secrecy::ExposeSecret;
 
-    use crate::keepass::key::SecretKey;
+    use crate::keepass::key::{memory, SecretKey};
 
     #[test]
     fn key_roundtrip() {
@@ -105,5 +99,25 @@ mod tests {
         let data = SecretKey::retrieve(&key.key_id, Duration::from_secs(10)).unwrap();
 
         assert_eq!(key.expose_secret(), data.expose_secret());
+    }
+
+    #[test]
+    fn memory_store_roundtrip_and_revoke() {
+        let secret = b"0123456789abcdef0123456789abcdef";
+
+        memory::store("test-key", secret, Duration::from_secs(10)).unwrap();
+        let data = memory::retrieve("test-key", Duration::from_secs(10)).unwrap();
+        assert_eq!(data.as_ref(), secret);
+
+        memory::revoke("test-key").unwrap();
+        assert!(memory::retrieve("test-key", Duration::from_secs(10)).is_err());
+    }
+
+    #[test]
+    fn memory_store_expires() {
+        let secret = b"0123456789abcdef0123456789abcdef";
+
+        memory::store("expiring-key", secret, Duration::from_secs(0)).unwrap();
+        assert!(memory::retrieve("expiring-key", Duration::from_secs(10)).is_err());
     }
 }

--- a/src/keepass/key/keyring.rs
+++ b/src/keepass/key/keyring.rs
@@ -22,11 +22,11 @@ pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()
 pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
     let keyr = get_keyring()?;
 
-    let mut key = keyr.search(key_id).map_err(map_err)?;
+    let key = keyr.search(key_id).map_err(map_err)?;
 
-    // TODO: determine buffer size
-    let mut data = vec![0; 32].into_boxed_slice();
-    key.read(&mut data).map_err(map_err)?;
+    // read the actual payload length instead of assuming 32 bytes,
+    // so secrets of any length roundtrip unchanged
+    let data = key.read_to_vec().map_err(map_err)?.into_boxed_slice();
 
     key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
 

--- a/src/keepass/key/keyring.rs
+++ b/src/keepass/key/keyring.rs
@@ -1,0 +1,56 @@
+// linux kernel keyring backed key store
+
+use std::time::Duration;
+
+use anyhow::Result;
+use linux_keyutils::{KeyError, KeyPermissions, KeyRing, KeyRingIdentifier};
+
+use super::KeyUnavailableError;
+
+const KEYRING_PERM: u32 = 0x3f000000;
+
+pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()> {
+    let keyr = get_keyring()?;
+
+    let key = keyr.add_key(key_id, secret).map_err(map_err)?;
+    key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
+    key.set_perms(KeyPermissions::from_u32(KEYRING_PERM)).map_err(map_err)?;
+
+    Ok(())
+}
+
+pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
+    let keyr = get_keyring()?;
+
+    let mut key = keyr.search(key_id).map_err(map_err)?;
+
+    // TODO: determine buffer size
+    let mut data = vec![0; 32].into_boxed_slice();
+    key.read(&mut data).map_err(map_err)?;
+
+    key.set_timeout(timeout.as_secs() as usize).map_err(map_err)?;
+
+    Ok(data)
+}
+
+pub(super) fn revoke(key_id: &str) -> Result<()> {
+    let keyr = get_keyring()?;
+
+    let key = keyr.search(key_id).map_err(map_err)?;
+    key.revoke().map_err(map_err)?;
+
+    Ok(())
+}
+
+fn map_err(err: KeyError) -> anyhow::Error {
+    match err {
+        KeyError::KeyDoesNotExist | KeyError::KeyExpired | KeyError::KeyRevoked => KeyUnavailableError.into(),
+        err => anyhow::Error::new(err),
+    }
+}
+
+fn get_keyring() -> Result<KeyRing> {
+    // TODO: Make other keyrings available
+    // TODO: Investigate why key in Process keyring doesn't persist
+    Ok(KeyRing::from_special_id(KeyRingIdentifier::Session, false)?)
+}

--- a/src/keepass/key/memory.rs
+++ b/src/keepass/key/memory.rs
@@ -1,0 +1,64 @@
+// in-memory key store for platforms without kernel keyrings.
+// keys stay in (zeroized-on-drop) process memory instead of the kernel,
+// which is weaker than the linux keyring but enables native macos/windows runs.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use zeroize::Zeroize;
+
+use super::KeyUnavailableError;
+
+struct Entry {
+    secret: Vec<u8>,
+    expiry: Instant,
+}
+
+impl Drop for Entry {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+fn entries() -> &'static Mutex<HashMap<String, Entry>> {
+    static STORE: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+    STORE.get_or_init(Default::default)
+}
+
+pub(super) fn store(key_id: &str, secret: &[u8], timeout: Duration) -> Result<()> {
+    let mut store = entries().lock().unwrap();
+
+    // drop expired keys so the map doesn't grow unboundedly
+    let now = Instant::now();
+    store.retain(|_, entry| now < entry.expiry);
+
+    store.insert(key_id.to_string(), Entry {
+        secret: secret.to_vec(),
+        expiry: now + timeout,
+    });
+
+    Ok(())
+}
+
+pub(super) fn retrieve(key_id: &str, timeout: Duration) -> Result<Box<[u8]>> {
+    let mut store = entries().lock().unwrap();
+
+    let entry = store.get_mut(key_id).ok_or(KeyUnavailableError)?;
+    if Instant::now() >= entry.expiry {
+        store.remove(key_id);
+        return Err(KeyUnavailableError.into());
+    }
+
+    entry.expiry = Instant::now() + timeout;
+    Ok(entry.secret.clone().into_boxed_slice())
+}
+
+pub(super) fn revoke(key_id: &str) -> Result<()> {
+    entries().lock().unwrap()
+        .remove(key_id)
+        .ok_or(KeyUnavailableError)?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod server;
 mod auth;
 mod keepass;
+mod rate_limit;
 mod session;
 
 const CONFIG_FILE: &str = "config.yml";

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ const CONFIG_FILE: &str = "config.yml";
 struct Args {
     #[arg(short, long, default_value = CONFIG_FILE)]
     config: std::path::PathBuf,
+    /// probe /health of a running instance and exit (for container healthchecks)
+    #[arg(long)]
+    health_check: bool,
 }
 
 #[actix_web::main]
@@ -26,6 +29,38 @@ async fn main() {
     let args = Args::parse();
     let config = Config::from_file(args.config).expect("Failed to parse config");
 
+    if args.health_check {
+        std::process::exit(health_check(config.port));
+    }
+
     Server::new(config)
         .await.expect("Failed to start server")
+}
+
+// minimal http probe without a shell or curl, usable from a scratch image
+fn health_check(port: u16) -> i32 {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let timeout = Duration::from_secs(3);
+    for addr in ["127.0.0.1", "::1"] {
+        let Ok(mut stream) = TcpStream::connect((addr, port)) else {
+            continue;
+        };
+        let _ = stream.set_read_timeout(Some(timeout));
+        let _ = stream.set_write_timeout(Some(timeout));
+
+        let request = format!("GET {} HTTP/1.0\r\nHost: localhost\r\n\r\n", server::route::ROUTE_HEALTH);
+        if stream.write_all(request.as_bytes()).is_err() {
+            continue;
+        }
+
+        let mut response = String::new();
+        if stream.read_to_string(&mut response).is_ok() && response.starts_with("HTTP/1.0 200") {
+            return 0;
+        }
+    }
+
+    1
 }

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+// failures before lockouts start
+const FREE_FAILURES: u32 = 5;
+const BASE_DELAY: Duration = Duration::from_secs(2);
+const MAX_DELAY: Duration = Duration::from_secs(15 * 60);
+
+struct Failures {
+    count: u32,
+    last_failure: Instant,
+}
+
+impl Failures {
+    fn blocked_until(&self) -> Option<Instant> {
+        if self.count <= FREE_FAILURES {
+            return None;
+        }
+        // exponential backoff: 2s, 4s, 8s, ... capped at 15 minutes
+        let exponent = (self.count - FREE_FAILURES - 1).min(30);
+        let delay = BASE_DELAY.saturating_mul(2u32.saturating_pow(exponent)).min(MAX_DELAY);
+        Some(self.last_failure + delay)
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.last_failure) > MAX_DELAY
+    }
+}
+
+// in-memory login throttle with exponential backoff,
+// keyed by caller-provided strings (e.g. "<ip>|<username>")
+#[derive(Default)]
+pub struct RateLimiter {
+    entries: Mutex<HashMap<String, Failures>>,
+}
+
+impl RateLimiter {
+    // remaining lockout, if the key is currently blocked
+    pub async fn check(&self, key: &str) -> Option<Duration> {
+        let entries = self.entries.lock().await;
+        let blocked_until = entries.get(key)?.blocked_until()?;
+        let now = Instant::now();
+        if now < blocked_until {
+            return Some(blocked_until - now);
+        }
+        None
+    }
+
+    pub async fn failure(&self, key: &str) {
+        let mut entries = self.entries.lock().await;
+
+        // drop stale entries so the map doesn't grow unboundedly
+        let now = Instant::now();
+        entries.retain(|_, f| !f.expired(now));
+
+        let failures = entries.entry(key.to_string()).or_insert(Failures {
+            count: 0,
+            last_failure: now,
+        });
+        failures.count += 1;
+        failures.last_failure = now;
+    }
+
+    pub async fn success(&self, key: &str) {
+        self.entries.lock().await.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn blocks_after_free_failures() {
+        let limiter = RateLimiter::default();
+        let key = "1.2.3.4|alice";
+
+        for _ in 0..FREE_FAILURES {
+            limiter.failure(key).await;
+            assert!(limiter.check(key).await.is_none());
+        }
+
+        limiter.failure(key).await;
+        assert!(limiter.check(key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn success_resets() {
+        let limiter = RateLimiter::default();
+        let key = "1.2.3.4|alice";
+
+        for _ in 0..FREE_FAILURES + 3 {
+            limiter.failure(key).await;
+        }
+        assert!(limiter.check(key).await.is_some());
+
+        limiter.success(key).await;
+        assert!(limiter.check(key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn keys_are_independent() {
+        let limiter = RateLimiter::default();
+
+        for _ in 0..FREE_FAILURES + 1 {
+            limiter.failure("1.2.3.4|alice").await;
+        }
+        assert!(limiter.check("1.2.3.4|alice").await.is_some());
+        assert!(limiter.check("5.6.7.8|alice").await.is_none());
+        assert!(limiter.check("1.2.3.4|bob").await.is_none());
+    }
+
+    #[test]
+    fn backoff_escalates_and_caps() {
+        let now = Instant::now();
+        let delay = |count| Failures { count, last_failure: now }
+            .blocked_until()
+            .map(|until| until - now);
+
+        assert_eq!(delay(FREE_FAILURES), None);
+        assert_eq!(delay(FREE_FAILURES + 1), Some(Duration::from_secs(2)));
+        assert_eq!(delay(FREE_FAILURES + 2), Some(Duration::from_secs(4)));
+        assert_eq!(delay(FREE_FAILURES + 3), Some(Duration::from_secs(8)));
+        assert_eq!(delay(FREE_FAILURES + 100), Some(MAX_DELAY));
+    }
+}

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -1,6 +1,7 @@
 use actix_files as fs;
 use actix_files::NamedFile;
-use actix_web::{Responder, web};
+use actix_web::{HttpResponse, Responder, web};
+use serde_json::json;
 
 use crate::server::route::auth::{
     authenticated,
@@ -28,6 +29,7 @@ pub mod util;
 pub const API_PATH: &str = "/api/v1";
 pub const STATIC_PATH: &str = "/assets";
 pub const INDEX_FILE: &str = "public/index.html";
+pub const ROUTE_HEALTH: &str = "/health";
 
 pub fn setup_routes(cfg: &mut web::ServiceConfig) {
     cfg
@@ -52,6 +54,9 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
 
         .service(callback_user_auth)
 
+        // unauthenticated liveness probe
+        .route(ROUTE_HEALTH, web::get().to(health))
+
         // static
         .route("/", web::get().to(index))
         .route("/keepass", web::get().to(index))
@@ -64,5 +69,13 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
 
 async fn index() -> impl Responder {
     NamedFile::open_async(INDEX_FILE).await
+}
+
+async fn health() -> impl Responder {
+    HttpResponse::Ok().json(json!(
+        {
+            "status": "ok",
+        }
+    ))
 }
 

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -10,9 +10,12 @@ use crate::server::route::auth::{
     close_db,
     db_login,
     logout,
+    save_db,
     user_login,
 };
 use crate::server::route::keepass::{
+    create_entry,
+    delete_entry,
     get_entry,
     get_file,
     get_group_entries,
@@ -20,6 +23,7 @@ use crate::server::route::keepass::{
     get_icon,
     get_protected,
     search_entries,
+    update_entry,
 };
 
 pub mod auth;
@@ -41,6 +45,7 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(db_login)
             .service(close_db)
             .service(logout)
+            .service(save_db)
 
             // keepass
             .service(get_groups)
@@ -50,6 +55,9 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(get_file)
             .service(search_entries)
             .service(get_icon)
+            .service(create_entry)
+            .service(update_entry)
+            .service(delete_entry)
         )
 
         .service(callback_user_auth)

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -15,6 +15,7 @@ use crate::server::route::auth::{
 };
 use crate::server::route::keepass::{
     create_entry,
+    create_group,
     delete_entry,
     get_entry,
     get_file,
@@ -22,6 +23,7 @@ use crate::server::route::keepass::{
     get_groups,
     get_icon,
     get_protected,
+    rename_group,
     search_entries,
     update_entry,
 };
@@ -58,6 +60,8 @@ pub fn setup_routes(cfg: &mut web::ServiceConfig) {
             .service(create_entry)
             .service(update_entry)
             .service(delete_entry)
+            .service(create_group)
+            .service(rename_group)
         )
 
         .service(callback_user_auth)

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -191,7 +191,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         error!("db login from '{}': failed to store key: {}", username, err);
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store key",
             }
         ));
@@ -204,7 +204,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         }
         return HttpResponse::InternalServerError().json(json!(
             {
-                "success": true,
+                "success": false,
                 "message": "failed to store db",
             }
         ));
@@ -221,7 +221,7 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
 fn get_user_info(session: &Session) -> Result<UserInfo, HttpResponse> {
     let resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to retrieve session",
         }
     ));

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -344,7 +344,7 @@ async fn embed_in_index(success: bool, message: Option<String>, data: Option<Ses
     let mut index = match tokio::fs::read_to_string(INDEX_FILE).await {
         Ok(v) => v,
         Err(err) => {
-            info!("user login from '{}': ", err);
+            error!("failed to read index file: {}", err);
             return HttpResponse::InternalServerError().json(json!(
                 {
                     "success": false,

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -60,7 +60,13 @@ async fn user_login(request: HttpRequest, session: Session, config: Data<Config>
         return err;
     }
 
-    let client_ip = request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string();
+    // forwarding headers are spoofable, only honor them when explicitly
+    // configured (i.e. behind a reverse proxy that sets them)
+    let client_ip = if config.trust_proxy_headers {
+        request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string()
+    } else {
+        request.peer_addr().map(|addr| addr.ip().to_string()).unwrap_or_else(|| "unknown".to_string())
+    };
     let rate_key = format!("{}|{}", client_ip, params.username.to_lowercase());
     if let Some(remaining) = rate_limiter.check(&rate_key).await {
         info!("user login from '{}' ({}): rate limited for {}s", params.username, client_ip, remaining.as_secs());

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -12,6 +12,7 @@ use crate::auth_backend::{AuthCache, SESSION_KEY_AUTH_STATE, UserInfo};
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::KeePass;
+use crate::rate_limit::RateLimiter;
 use crate::server::route::INDEX_FILE;
 use crate::server::route::util::{_close_db, check_user_session, db_is_open, revoke_key, set_user_session, store_key};
 use crate::session::AuthSession;
@@ -54,9 +55,21 @@ async fn authenticated(session: Session, config: Data<Config>, db_cache: Data<Db
 
 
 #[post("/user_login")]
-async fn user_login(session: Session, config: Data<Config>, params: web::Form<UserLogin>) -> impl Responder {
+async fn user_login(request: HttpRequest, session: Session, config: Data<Config>, rate_limiter: Data<RateLimiter>, params: web::Form<UserLogin>) -> impl Responder {
     if let Err(err) = check_user_session(&session, &params.username) {
         return err;
+    }
+
+    let client_ip = request.connection_info().realip_remote_addr().unwrap_or("unknown").to_string();
+    let rate_key = format!("{}|{}", client_ip, params.username.to_lowercase());
+    if let Some(remaining) = rate_limiter.check(&rate_key).await {
+        info!("user login from '{}' ({}): rate limited for {}s", params.username, client_ip, remaining.as_secs());
+        return HttpResponse::TooManyRequests().json(json!(
+            {
+                "success": false,
+                "message": "too many failed login attempts, try again later",
+            }
+        ));
     }
 
     let auth_backend = auth_backend::new(&config);
@@ -64,6 +77,7 @@ async fn user_login(session: Session, config: Data<Config>, params: web::Form<Us
     let user_info = match auth_backend.login(params.username.as_str(), params.password.as_str()).await {
         Ok(user_info) => user_info,
         Err(err) => {
+            rate_limiter.failure(&rate_key).await;
             info!("user login from '{}': {}", params.username, err);
             return HttpResponse::Unauthorized().json(json!(
                 {
@@ -73,6 +87,7 @@ async fn user_login(session: Session, config: Data<Config>, params: web::Form<Us
             ));
         }
     };
+    rate_limiter.success(&rate_key).await;
 
     let csrf_token = match set_user_session(session, &user_info) {
         Ok(v) => v,

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -14,7 +14,7 @@ use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::KeePass;
 use crate::rate_limit::RateLimiter;
 use crate::server::route::INDEX_FILE;
-use crate::server::route::util::{_close_db, check_user_session, db_is_open, revoke_key, set_user_session, store_key};
+use crate::server::route::util::{_close_db, check_user_session, db_is_open, get_db, revoke_key, set_user_session, store_key};
 use crate::session::AuthSession;
 
 #[derive(Serialize)]
@@ -179,8 +179,8 @@ async fn db_login(session: Session, config: Data<Config>, db_cache: Data<DbCache
         Err(err) => return err,
     };
 
-    let db_backend = db_backend::new(&config);
-    let db = match KeePass::from_backend(&config, db_backend.as_ref(), &params, &user_info).await {
+    let mut db_backend = db_backend::new(&config);
+    let db = match KeePass::from_backend(&config, db_backend.as_mut(), &params, &user_info).await {
         Ok(v) => v,
         Err(err) => {
             info!("db login from '{}': {}", username, err);
@@ -306,6 +306,44 @@ async fn logout(request: HttpRequest, session: Session, config: Data<Config>, db
             "data": logout_type,
         }
     ))
+}
+
+#[post("/save_db")]
+async fn save_db(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<DbLogin>) -> impl Responder {
+    let username = session.get_user_id();
+
+    let keepass = match get_db(&session, &config, &db_cache).await {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
+
+    let user_info = match get_user_info(&session) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
+
+    let mut db_backend = db_backend::new(&config);
+    let db_key = match KeePass::db_key_from_params_pub(db_backend.as_ref(), &params, &user_info).await {
+        Ok(k) => k,
+        Err(err) => {
+            info!("save_db from '{}': {}", username, err);
+            return HttpResponse::Unauthorized().json(json!({
+                "success": false,
+                "message": "incorrect key",
+            }));
+        }
+    };
+
+    if let Err(err) = keepass.to_backend_with_key(db_backend.as_mut(), db_key, &user_info).await {
+        error!("save_db from '{}': {}", username, err);
+        return HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to save database",
+        }));
+    }
+
+    info!("save_db from '{}': successful", username);
+    HttpResponse::Ok().json(json!({ "success": true }))
 }
 
 #[get("/callback_user_auth")]

--- a/src/server/route/auth.rs
+++ b/src/server/route/auth.rs
@@ -279,7 +279,7 @@ async fn logout(request: HttpRequest, session: Session, config: Data<Config>, db
     };
 
     let host = format!("{}://{}", request.connection_info().scheme(), request.connection_info().host());
-    let logout_type = match auth_backend::new(&config).get_logout_type(&user_info, &host, &auth_cache) {
+    let logout_type = match auth_backend::new(&config).get_logout_type(&user_info, &host, &auth_cache).await {
         Ok(logout_type) => logout_type,
         Err(err) => {
             error!("failed to determine logout type: {}", err);

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -21,6 +21,7 @@ struct NewEntry {
     password: String,
     url: String,
     notes: String,
+    icon: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -31,6 +32,7 @@ struct UpdateEntry {
     password: String,
     url: String,
     notes: String,
+    icon: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -264,6 +266,7 @@ async fn create_entry(session: Session, config: Data<Config>, db_cache: Data<DbC
             &params.password,
             &params.url,
             &params.notes,
+            params.icon,
         )?;
         Ok(())
     }).await {
@@ -286,6 +289,7 @@ async fn update_entry(session: Session, config: Data<Config>, db_cache: Data<DbC
             &params.password,
             &params.url,
             &params.notes,
+            params.icon,
         )
     }).await {
         return err;

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -133,26 +133,17 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
 
 #[get("/get_file")]
 async fn get_file(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Query<File>) -> impl Responder {
-    let keepass = match util::get_db(&session, &config, &db_cache).await {
-        Ok(v) => v,
-        Err(err) => return err,
+    if let Err(err) = util::get_db(&session, &config, &db_cache).await {
+        return err;
     };
 
-    let username = session.get_user_id();
-    let file = match keepass.get_file(&params) {
-        Ok(v) => v,
-        Err(err) => {
-            info!("{}: failed to get file '{}' of entry '{}': {}", username, params.filename, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get file",
-                }
-            ));
+    info!("{}: file download requested for '{}' of entry '{}', but it is not implemented", session.get_user_id(), params.filename, params.entry_id);
+    HttpResponse::NotImplemented().json(json!(
+        {
+            "success": false,
+            "message": "file download is not implemented yet",
         }
-    };
-
-    HttpResponse::Ok().body(file)
+    ))
 }
 
 #[get("/search_entries")]

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -1,15 +1,37 @@
 use actix_session::Session;
-use actix_web::{get, HttpResponse, Responder, web};
+use actix_web::{delete, get, post, put, HttpResponse, Responder, web};
 use actix_web::web::Data;
 use log::info;
+use serde::Deserialize;
 use serde_json::json;
 use secrecy::ExposeSecret;
+use uuid::Uuid;
 
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
 use crate::keepass::keepass::{File, Id, NotFoundError, Protected, SearchTerm};
 use crate::server::route::util;
 use crate::session::AuthSession;
+
+#[derive(Deserialize)]
+struct NewEntry {
+    group_id: Uuid,
+    title: String,
+    username: String,
+    password: String,
+    url: String,
+    notes: String,
+}
+
+#[derive(Deserialize)]
+struct UpdateEntry {
+    id: Uuid,
+    title: String,
+    username: String,
+    password: String,
+    url: String,
+    notes: String,
+}
 
 // 404 for missing entries/groups/icons, 500 for everything else
 fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
@@ -215,6 +237,64 @@ fn icon_mime(data: &[u8]) -> &'static str {
         // previous behavior, custom icons are usually png
         "image/png"
     }
+}
+
+#[post("/entry")]
+async fn create_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<NewEntry>) -> impl Responder {
+    let username = session.get_user_id();
+    let mut new_id = Uuid::nil();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        new_id = kp.create_entry(
+            &params.group_id,
+            &params.title,
+            &params.username,
+            &params.password,
+            &params.url,
+            &params.notes,
+        )?;
+        Ok(())
+    }).await {
+        return err;
+    }
+
+    info!("create_entry from '{}': {}", username, new_id);
+    HttpResponse::Ok().json(json!({ "success": true, "data": { "id": new_id } }))
+}
+
+#[put("/entry")]
+async fn update_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<UpdateEntry>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.update_entry(
+            &params.id,
+            &params.title,
+            &params.username,
+            &params.password,
+            &params.url,
+            &params.notes,
+        )
+    }).await {
+        return err;
+    }
+
+    info!("update_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
+}
+
+#[delete("/entry")]
+async fn delete_entry(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Query<Id>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.delete_entry(&params.id)
+    }).await {
+        return err;
+    }
+
+    info!("delete_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
 }
 
 #[cfg(test)]

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -2,15 +2,28 @@ use actix_session::Session;
 use actix_web::{get, HttpResponse, Responder, web};
 use actix_web::web::Data;
 use log::info;
-use mime::IMAGE_PNG;
 use serde_json::json;
 use secrecy::ExposeSecret;
 
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
-use crate::keepass::keepass::{File, Id, Protected, SearchTerm};
+use crate::keepass::keepass::{File, Id, NotFoundError, Protected, SearchTerm};
 use crate::server::route::util;
 use crate::session::AuthSession;
+
+// 404 for missing entries/groups/icons, 500 for everything else
+fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
+    let resp = json!(
+        {
+            "success": false,
+            "message": message,
+        }
+    );
+    if err.downcast_ref::<NotFoundError>().is_some() {
+        return HttpResponse::NotFound().json(resp);
+    }
+    HttpResponse::InternalServerError().json(resp)
+}
 
 #[get("/get_groups")]
 async fn get_groups(session: Session, config: Data<Config>, db_cache: Data<DbCache>) -> impl Responder {
@@ -56,12 +69,7 @@ async fn get_group_entries(session: Session, config: Data<Config>, db_cache: Dat
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entries for group '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get group entries",
-                }
-            ));
+            return error_response(&err, "failed to get group entries");
         }
     };
 
@@ -85,12 +93,7 @@ async fn get_entry(session: Session, config: Data<Config>, db_cache: Data<DbCach
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get entry '{}': {}", username, params.id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get entry",
-                }
-            ));
+            return error_response(&err, "failed to get entry");
         }
     };
 
@@ -114,12 +117,7 @@ async fn get_protected(session: Session, config: Data<Config>, db_cache: Data<Db
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get protected '{}' of entry '{}': {}", username, params.name, params.entry_id, err);
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get protected field",
-                }
-            ));
+            return error_response(&err, "failed to get protected field");
         }
     };
 
@@ -192,22 +190,53 @@ async fn get_icon(session: Session, config: Data<Config>, db_cache: Data<DbCache
         Ok(v) => v,
         Err(err) => {
             info!("{}: failed to get icon '{}': {}", username, params.id, err);
-            // TODO: Serve 404 if icon not found
-            return HttpResponse::InternalServerError().json(json!(
-                {
-                    "success": false,
-                    "message": "failed to get icon",
-                }
-            ));
+            return error_response(&err, "failed to get icon");
         }
     };
 
     HttpResponse::Ok()
         // UUID is unique, cache this forever
-        .append_header(("Cache-Control", "max-age=31536000; public; s-max-age=31536000"))
+        .append_header(("Cache-Control", "public, max-age=31536000, s-maxage=31536000, immutable"))
         .append_header(("ETag", icon.uuid.to_string()))
-        // TODO: sniff content type?
-        .content_type(IMAGE_PNG)
+        .content_type(icon_mime(&icon.data))
         .body(icon.data.clone())
+}
+
+fn icon_mime(data: &[u8]) -> &'static str {
+    if data.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "image/png"
+    } else if data.starts_with(b"\xff\xd8\xff") {
+        "image/jpeg"
+    } else if data.starts_with(b"GIF8") {
+        "image/gif"
+    } else if data.starts_with(b"<svg") || data.starts_with(b"<?xml") {
+        "image/svg+xml"
+    } else {
+        // previous behavior, custom icons are usually png
+        "image/png"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_mime_detection() {
+        assert_eq!(icon_mime(b"\x89PNG\r\n\x1a\nrest"), "image/png");
+        assert_eq!(icon_mime(b"\xff\xd8\xff\xe0rest"), "image/jpeg");
+        assert_eq!(icon_mime(b"GIF89a"), "image/gif");
+        assert_eq!(icon_mime(b"<svg xmlns="), "image/svg+xml");
+        assert_eq!(icon_mime(b"unknown"), "image/png");
+    }
+
+    #[test]
+    fn not_found_maps_to_404() {
+        let err: anyhow::Error = NotFoundError("entry").into();
+        assert_eq!(error_response(&err, "msg").status(), 404);
+
+        let err = anyhow::anyhow!("other");
+        assert_eq!(error_response(&err, "msg").status(), 500);
+    }
 }
 

--- a/src/server/route/keepass.rs
+++ b/src/server/route/keepass.rs
@@ -33,6 +33,18 @@ struct UpdateEntry {
     notes: String,
 }
 
+#[derive(Deserialize)]
+struct NewGroup {
+    parent_id: Uuid,
+    title: String,
+}
+
+#[derive(Deserialize)]
+struct RenameGroup {
+    id: Uuid,
+    title: String,
+}
+
 // 404 for missing entries/groups/icons, 500 for everything else
 fn error_response(err: &anyhow::Error, message: &str) -> HttpResponse {
     let resp = json!(
@@ -280,6 +292,36 @@ async fn update_entry(session: Session, config: Data<Config>, db_cache: Data<DbC
     }
 
     info!("update_entry from '{}': {}", username, params.id);
+    HttpResponse::Ok().json(json!({ "success": true }))
+}
+
+#[post("/group")]
+async fn create_group(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<NewGroup>) -> impl Responder {
+    let username = session.get_user_id();
+    let mut new_id = Uuid::nil();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        new_id = kp.create_group(&params.parent_id, &params.title)?;
+        Ok(())
+    }).await {
+        return err;
+    }
+
+    info!("create_group from '{}': {} under {}", username, params.title, params.parent_id);
+    HttpResponse::Ok().json(json!({ "success": true, "data": { "id": new_id } }))
+}
+
+#[put("/group")]
+async fn rename_group(session: Session, config: Data<Config>, db_cache: Data<DbCache>, params: web::Form<RenameGroup>) -> impl Responder {
+    let username = session.get_user_id();
+
+    if let Err(err) = util::modify_db(&session, &config, &db_cache, |kp| {
+        kp.rename_group(&params.id, &params.title)
+    }).await {
+        return err;
+    }
+
+    info!("rename_group from '{}': {} -> '{}'", username, params.id, params.title);
     HttpResponse::Ok().json(json!({ "success": true }))
 }
 

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -66,7 +66,7 @@ pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow
 pub(crate) async fn _close_db(session: &Session, config: &Config, db_cache: &DbCache) -> Result<(), HttpResponse> {
     let err_resp = HttpResponse::InternalServerError().json(json!(
         {
-            "success": true,
+            "success": false,
             "message": "failed to close db",
         }
     ));

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -1,7 +1,6 @@
 use actix_session::Session;
 use actix_web::HttpResponse;
 use anyhow::{anyhow, bail};
-use linux_keyutils::KeyError;
 use log::{error, info};
 use serde_json::json;
 
@@ -10,7 +9,7 @@ use crate::auth_backend::UserInfo;
 use crate::config::config::Config;
 use crate::keepass::db_cache::{CacheExpiredError, DbCache};
 use crate::keepass::keepass::KeePass;
-use crate::keepass::key::{KeyId, SecretKey};
+use crate::keepass::key::{KeyId, KeyUnavailableError, SecretKey};
 use crate::session::AuthSession;
 
 pub const SESSION_KEY_KEY_ID: &str = "key_id";
@@ -125,7 +124,7 @@ pub(crate) async fn get_db(session: &Session, config: &Config, db_cache: &DbCach
                 }
             );
 
-            return match err.downcast_ref::<KeyError>() {
+            return match err.downcast_ref::<KeyUnavailableError>() {
                 Some(_) => {
                     _close_db(session, config, db_cache).await?;
 
@@ -197,12 +196,9 @@ pub(crate) fn revoke_key(config: &Config, session: &Session) -> anyhow::Result<(
 fn check_key_err<F>(ok: F, err: anyhow::Error) -> anyhow::Result<()>
     where F: Fn() -> anyhow::Result<()>
 {
-    match err.downcast_ref::<KeyError>() {
-        Some(e) => match e {
-            // Ignore non-existent, expired or already revoked
-            KeyError::KeyDoesNotExist | KeyError::KeyExpired | KeyError::KeyRevoked => ok(),
-            _ => Err(err),
-        }
+    // Ignore non-existent, expired or already revoked
+    match err.downcast_ref::<KeyUnavailableError>() {
+        Some(_) => ok(),
         None => Err(err),
     }
 }

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -47,6 +47,9 @@ pub(crate) fn check_user_session(session: &Session, username: &str) -> Result<()
 }
 
 pub(crate) fn set_user_session(session: Session, user_info: &UserInfo) -> anyhow::Result<CsrfToken> {
+    // rotate the session on privilege change to prevent session fixation
+    session.renew();
+
     if let Err(err) = session.insert(SESSION_KEY_USER, user_info) {
         session.destroy();
         error!("user login from '{}': {}", user_info.id, err);

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -162,6 +162,60 @@ pub(crate) async fn db_is_open(session: &Session, config: &Config, db_cache: &Db
     Ok(true)
 }
 
+/// Decrypt the cached database, run `modify`, then re-encrypt and store back.
+/// The old session key is revoked and replaced with a fresh one.
+pub(crate) async fn modify_db<F>(
+    session: &Session,
+    config: &Config,
+    db_cache: &DbCache,
+    modify: F,
+) -> Result<(), HttpResponse>
+where
+    F: FnOnce(&mut KeePass) -> anyhow::Result<()>,
+{
+    let mut keepass = get_db(session, config, db_cache).await?;
+
+    if let Err(err) = modify(&mut keepass) {
+        return Err(HttpResponse::UnprocessableEntity().json(json!({
+            "success": false,
+            "message": err.to_string(),
+        })));
+    }
+
+    let (new_key, new_enc) = match keepass.to_enc() {
+        Ok(v) => v,
+        Err(err) => {
+            error!("failed to re-encrypt database after modification: {}", err);
+            return Err(HttpResponse::InternalServerError().json(json!({
+                "success": false,
+                "message": "failed to encrypt database",
+            })));
+        }
+    };
+
+    // Revoke the old key before storing the new one so it is replaced atomically
+    // from the session's perspective (the old key_id is still in the session here).
+    let _ = revoke_key(config, session);
+
+    if let Err(err) = store_key(config, session, new_key) {
+        error!("failed to store new key after modification: {}", err);
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to store key",
+        })));
+    }
+
+    if let Err(err) = db_cache.store(session, new_enc).await {
+        error!("failed to store modified database: {}", err);
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "message": "failed to store database",
+        })));
+    }
+
+    Ok(())
+}
+
 pub(crate) fn retrieve_key(config: &Config, session: &Session) -> anyhow::Result<SecretKey> {
     let key_id = session.get::<KeyId>(SESSION_KEY_KEY_ID)?
         .ok_or(anyhow!("failed to retrieve key id from session"))?;

--- a/src/server/route/util.rs
+++ b/src/server/route/util.rs
@@ -166,11 +166,11 @@ pub(crate) fn retrieve_key(config: &Config, session: &Session) -> anyhow::Result
     let key_id = session.get::<KeyId>(SESSION_KEY_KEY_ID)?
         .ok_or(anyhow!("failed to retrieve key id from session"))?;
 
-    SecretKey::retrieve(&key_id, config.db_session_timeout)
+    SecretKey::retrieve(&key_id, config.db_session_timeout, config.use_keyring)
 }
 
 pub(crate) fn store_key(config: &Config, session: &Session, mut key: SecretKey) -> anyhow::Result<()> {
-    key.store(config.db_session_timeout)?;
+    key.store(config.db_session_timeout, config.use_keyring)?;
     session.insert(SESSION_KEY_KEY_ID, key.key_id)?;
 
     Ok(())

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -8,6 +8,7 @@ use env_logger::Env;
 use crate::{auth, auth_backend};
 use crate::config::config::Config;
 use crate::keepass::db_cache::DbCache;
+use crate::rate_limit::RateLimiter;
 use crate::server::route::setup_routes;
 
 pub struct Server;
@@ -22,11 +23,13 @@ impl Server {
         let config_data = web::Data::new(config);
         let auth_cache = web::Data::new(auth_backend::new(&config_data).init().await?);
         let db_cache = web::Data::new(DbCache::default());
+        let rate_limiter = web::Data::new(RateLimiter::default());
 
         HttpServer::new(move || {
             App::new()
                 .app_data(db_cache.clone())
                 .app_data(auth_cache.clone())
+                .app_data(rate_limiter.clone())
                 .app_data(config_data.clone())
                 .wrap(auth::CheckAuth)
                 .wrap(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,7 +1,7 @@
 use actix_session::{config::PersistentSession, SessionMiddleware, storage::CookieSessionStore};
 use actix_web::{App, HttpServer, web};
 use actix_web::cookie::time::Duration;
-use actix_web::middleware::Logger;
+use actix_web::middleware::{DefaultHeaders, Logger};
 use anyhow::Result;
 use env_logger::Env;
 
@@ -45,6 +45,16 @@ impl Server {
                         .build(),
                 )
                 .wrap(Logger::default())
+                // registered last = outermost, so the headers are also set on
+                // responses short-circuited by the middlewares above.
+                // CSP is omitted for now: the index page relies on
+                // inline script injection (see embed_in_index)
+                .wrap(
+                    DefaultHeaders::new()
+                        .add(("X-Frame-Options", "DENY"))
+                        .add(("X-Content-Type-Options", "nosniff"))
+                        .add(("Referrer-Policy", "no-referrer"))
+                )
                 .configure(setup_routes)
         }).bind((server, port))?
             .run()

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -1,0 +1,42 @@
+{
+  "realm": "keepass",
+  "enabled": true,
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "keepass4web",
+      "name": "KeePass4Web",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "insecure-example-client-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/callback_user_auth",
+        "http://127.0.0.1:8080/callback_user_auth"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "testuser@example.org",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/keycloak/realm.json
+++ b/tests/keycloak/realm.json
@@ -15,10 +15,15 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [
         "http://localhost:8080/callback_user_auth",
-        "http://127.0.0.1:8080/callback_user_auth"
+        "http://127.0.0.1:8080/callback_user_auth",
+        "http://localhost:8088/callback_user_auth",
+        "http://127.0.0.1:8088/callback_user_auth",
+        "http://keycloak:8088/callback_user_auth"
       ],
       "webOrigins": [
-        "http://localhost:8080"
+        "http://localhost:8080",
+        "http://localhost:8088",
+        "http://keycloak:8088"
       ]
     }
   ],


### PR DESCRIPTION
Closes #323

## What this changes

Replaces the Bootstrap-grid vault view with a purpose-built flat UI — no Bootstrap in the vault, only for login pages.

## Layout

Three fixed panels:
- **Sidebar** (224 px) — group tree, "+" root-group button, collapses to a slide-in drawer on mobile (≤700 px)
- **Center** — entry cards (icon · title · username/URL · hover actions), sticky header with group rename, "Add Group", "New Entry"
- **Detail panel** (440 px) — read-only entry view **or** create/edit form; slides up from bottom on tablet (≤900 px)

## CSS design system (`js/style/vault.css`)

- All tokens are `--kp-*` custom properties — one place to retheme
- **Light + dark themes**: moon/sun toggle in navbar, choice saved in `localStorage`
- No Bootstrap classes inside the vault; login pages unchanged

## Icon picker

- 10-column grid of all 69 standard KeePass icons on the entry form
- Selected icon is stored in the KeePass database (`entry.icon_id`)
- Backend `create_entry` / `update_entry` accept optional `icon: Option<usize>`

## Component changes

| File | Change |
|------|--------|
| `js/style/vault.css` | **new** — full design system |
| `js/scripts/EntryForm.js` | **new** — right-panel create/edit form |
| `js/scripts/Icons.js` | **new** — inline SVG icon set |
| `public/preview.html` | **new** — standalone preview (no build needed) |
| `NavBar.js` | rewritten — inline search, dropdown, theme toggle |
| `TreeViewer.js` / `TreeNode.js` | rewritten — `kp-tree-*` classes, expand/collapse |
| `GroupViewer.js` | rewritten — entry cards, delegates forms to parent |
| `NodeViewer.js` | rewritten — React-state reveal/hide, copy feedback |
| `Viewport.js` | rewritten — three-panel orchestrator, `rightPanel` state |
| `DBLogin.js` | updated — custom file picker, modern layout |
| `src/keepass/keepass.rs` | updated — `create_entry`/`update_entry` accept `icon` |
| `src/server/route/keepass.rs` | updated — `NewEntry`/`UpdateEntry` have `icon` field |

## Testing

Tested locally with the Docker Compose stack (OIDC via Keycloak). The `public/preview.html` file can be opened directly in any browser to preview the layout without the backend.